### PR TITLE
feat: 수업 템플릿 목록 페이지 구현

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -4,7 +4,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   return (
     <div style={{ display: 'flex' }}>
       <Sidebar />
-      <main style={{ marginLeft: '240px', flex: 1, padding: '48px 0px' }}>
+      <main style={{ marginLeft: '240px', flex: 1, padding: '48px 48px' }}>
         {children}
       </main>
     </div>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,10 +1,11 @@
 import Sidebar from '@/components/common/Sidebar'
+import { colors } from '@/styles/tokens/colors'
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   return (
     <div style={{ display: 'flex' }}>
       <Sidebar />
-      <main style={{ marginLeft: '240px', flex: 1, padding: '48px 48px' }}>
+      <main style={{ marginLeft: '240px', flex: 1, minHeight: '100vh', padding: '48px 48px', backgroundColor: colors.background }}>
         {children}
       </main>
     </div>

--- a/src/app/(main)/template/_components/DeleteConfirmModal/DeleteConfirmModal.css.ts
+++ b/src/app/(main)/template/_components/DeleteConfirmModal/DeleteConfirmModal.css.ts
@@ -1,0 +1,19 @@
+import { style } from '@vanilla-extract/css'
+
+export const deleteModalContentStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  marginBottom: '36px',
+  marginTop: '44px',
+  textAlign: 'center',
+  alignItems: 'center',
+})
+
+export const titleStyle = style({
+  marginBottom: '12px',
+})
+
+export const deleteModalActionsStyle = style({
+  display: 'flex',
+  gap: '8px',
+})

--- a/src/app/(main)/template/_components/DeleteConfirmModal/DeleteConfirmModal.tsx
+++ b/src/app/(main)/template/_components/DeleteConfirmModal/DeleteConfirmModal.tsx
@@ -1,0 +1,38 @@
+import Modal from '@/components/common/Modal'
+import Button from '@/components/common/Button'
+import Text from '@/components/common/Text'
+import { deleteModalContentStyle, deleteModalActionsStyle, titleStyle } from './DeleteConfirmModal.css'
+
+interface DeleteConfirmModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+  templateName: string
+  classCount: number
+}
+
+export default function DeleteConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  templateName,
+  classCount,
+}: DeleteConfirmModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="sm">
+      <div className={deleteModalContentStyle}>
+        <Text variant="headingMd" as="h2" className={titleStyle}>'{templateName}'을 삭제할까요?</Text>
+        <Text variant="bodyLg" color="gray500">
+          현재 {classCount}개의 반에서 사용하고 있어요.
+        </Text>
+        <Text variant="bodyLg" color="gray500">
+          삭제 후에는 복구할 수 없어요.
+        </Text>
+      </div>
+      <div className={deleteModalActionsStyle}>
+        <Button variant="ghost" size="md" fullWidth onClick={onClose}>취소</Button>
+        <Button variant="danger" size="md" fullWidth onClick={onConfirm}>삭제</Button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/app/(main)/template/_components/TemplateCard/TemplateCard.css.ts
+++ b/src/app/(main)/template/_components/TemplateCard/TemplateCard.css.ts
@@ -1,0 +1,68 @@
+import { style } from '@vanilla-extract/css'
+import { colors } from '@/styles/tokens/colors'
+import { fontStyles } from '@/styles/tokens/typography'
+
+export const cardStyle = style({
+  backgroundColor: colors.white,
+  border: `1px solid ${colors.gray100}`,
+  borderRadius: '16px',
+  padding: '24px',
+  cursor: 'pointer',
+  transition: 'background-color 0.2s',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+  selectors: {
+    '&:hover': {
+      backgroundColor: colors.primary50,
+    },
+  },
+})
+
+export const cardHeaderStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+})
+
+export const iconGroupStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+})
+
+export const iconButtonStyle = style({
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  padding: '4px',
+  color: colors.gray100,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  transition: 'color 0.2s',
+  selectors: {
+    '&:hover': {
+      color: colors.gray300,
+    },
+  },
+})
+
+export const classCountStyle = style({
+  fontSize: fontStyles.titleSm.fontSize,
+  fontWeight: fontStyles.titleSm.fontWeight,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+  color: colors.gray500,
+})
+
+export const countHighlightStyle = style({
+  color: colors.primary500,
+  fontWeight: fontStyles.titleSm.fontWeight,
+})
+
+export const chipGroupStyle = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '4px',
+})

--- a/src/app/(main)/template/_components/TemplateCard/TemplateCard.css.ts
+++ b/src/app/(main)/template/_components/TemplateCard/TemplateCard.css.ts
@@ -11,7 +11,7 @@ export const cardStyle = style({
   transition: 'background-color 0.2s',
   display: 'flex',
   flexDirection: 'column',
-  gap: '8px',
+  gap: '12px',
   selectors: {
     '&:hover': {
       backgroundColor: colors.primary50,
@@ -21,14 +21,9 @@ export const cardStyle = style({
 
 export const cardHeaderStyle = style({
   display: 'flex',
-  alignItems: 'center',
+  alignItems: 'flex-start',
   justifyContent: 'space-between',
-})
-
-export const iconGroupStyle = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '4px',
+  marginBottom: '8px',
 })
 
 export const iconButtonStyle = style({

--- a/src/app/(main)/template/_components/TemplateCard/TemplateCard.tsx
+++ b/src/app/(main)/template/_components/TemplateCard/TemplateCard.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import Text from '@/components/common/Text'
+import Chip from '@/components/common/Chip'
+import EditIcon from '@/assets/icons/icon-edit.svg'
+import TrashIcon from '@/assets/icons/icon-trash.svg'
+import {
+  cardStyle,
+  cardHeaderStyle,
+  iconGroupStyle,
+  iconButtonStyle,
+  classCountStyle,
+  countHighlightStyle,
+  chipGroupStyle,
+} from './TemplateCard.css'
+
+interface TemplateCardProps {
+  id: number
+  title: string
+  classCount: number
+  classList: string[]
+  onDelete: (id: number) => void
+}
+
+export default function TemplateCard({
+  id,
+  title,
+  classCount,
+  classList,
+  onDelete,
+}: TemplateCardProps) {
+  const router = useRouter()
+
+  return (
+    <div
+      className={cardStyle}
+      onClick={() => router.push(`/template/${id}`)}
+    >
+      <div className={cardHeaderStyle}>
+        <div />
+        <div className={iconGroupStyle}>
+          <button
+            className={iconButtonStyle}
+            onClick={(e) => {
+              e.stopPropagation()
+              router.push(`/template/${id}/edit`)
+            }}
+          >
+            <EditIcon width={16} height={16} />
+          </button>
+          <button
+            className={iconButtonStyle}
+            onClick={(e) => {
+              e.stopPropagation()
+              onDelete(id)
+            }}
+          >
+            <TrashIcon width={16} height={16} />
+          </button>
+        </div>
+      </div>
+      <Text variant="headingLg" as="h3">{title}</Text>
+      <p className={classCountStyle}>
+        사용 중인 반 <span className={countHighlightStyle}>{classCount}</span>
+      </p>
+      <div className={chipGroupStyle}>
+        {classList.map((name) => (
+          <Chip key={name} variant="default" label={name} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/template/_components/TemplateCard/TemplateCard.tsx
+++ b/src/app/(main)/template/_components/TemplateCard/TemplateCard.tsx
@@ -3,12 +3,11 @@
 import { useRouter } from 'next/navigation'
 import Text from '@/components/common/Text'
 import Chip from '@/components/common/Chip'
-import EditIcon from '@/assets/icons/icon-edit.svg'
+
 import TrashIcon from '@/assets/icons/icon-trash.svg'
 import {
   cardStyle,
   cardHeaderStyle,
-  iconGroupStyle,
   iconButtonStyle,
   classCountStyle,
   countHighlightStyle,
@@ -33,34 +32,21 @@ export default function TemplateCard({
   const router = useRouter()
 
   return (
-    <div
-      className={cardStyle}
-      onClick={() => router.push(`/template/${id}`)}
-    >
+    <div className={cardStyle} onClick={() => router.push(`/template/${id}`)}>
       <div className={cardHeaderStyle}>
-        <div />
-        <div className={iconGroupStyle}>
-          <button
-            className={iconButtonStyle}
-            onClick={(e) => {
-              e.stopPropagation()
-              router.push(`/template/${id}/edit`)
-            }}
-          >
-            <EditIcon width={16} height={16} />
-          </button>
-          <button
-            className={iconButtonStyle}
-            onClick={(e) => {
-              e.stopPropagation()
-              onDelete(id)
-            }}
-          >
-            <TrashIcon width={16} height={16} />
-          </button>
-        </div>
+        <Text variant="headingLg" as="h3">
+          {title}
+        </Text>
+        <button
+          className={iconButtonStyle}
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete(id)
+          }}
+        >
+          <TrashIcon width={24} height={24} />
+        </button>
       </div>
-      <Text variant="headingLg" as="h3">{title}</Text>
       <p className={classCountStyle}>
         사용 중인 반 <span className={countHighlightStyle}>{classCount}</span>
       </p>

--- a/src/app/(main)/template/page.tsx
+++ b/src/app/(main)/template/page.tsx
@@ -1,3 +1,56 @@
+'use client'
+
+import TemplateCard from './_components/TemplateCard/TemplateCard'
+import { gridStyle } from './template.css'
+import Text from '@/components/common/Text'
+const MOCK_TEMPLATES = [
+  {
+    id: 1,
+    title: '정규 수업 템플릿1',
+    classCount: 4,
+    classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'],
+  },
+  {
+    id: 2,
+    title: '보강 수업 템플릿',
+    classCount: 4,
+    classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'],
+  },
+  {
+    id: 3,
+    title: '방학 특강 템플릿',
+    classCount: 4,
+    classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'],
+  },
+  {
+    id: 4,
+    title: '정규 수업 템플릿2',
+    classCount: 4,
+    classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'],
+  },
+  {
+    id: 5,
+    title: '시험대비 클리닉 템플릿',
+    classCount: 4,
+    classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'],
+  },
+]
+
 export default function TemplatePage() {
-    return <div>수업 템플릿</div>
-  }
+  return (
+    <div>
+      <Text variant="display" as="h1">
+        수업 템플릿
+      </Text>
+      <div className={gridStyle}>
+        {MOCK_TEMPLATES.map((template) => (
+          <TemplateCard
+            key={template.id}
+            {...template}
+            onDelete={(id) => console.log('delete', id)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/template/page.tsx
+++ b/src/app/(main)/template/page.tsx
@@ -1,56 +1,59 @@
 'use client'
 
-import TemplateCard from './_components/TemplateCard/TemplateCard'
-import { gridStyle } from './template.css'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Text from '@/components/common/Text'
+import AddCard from '@/components/common/AddCard'
+import TemplateCard from './_components/TemplateCard/TemplateCard'
+import DeleteConfirmModal from './_components/DeleteConfirmModal/DeleteConfirmModal'
+import PlusCircleIcon from '@/assets/icons/icon-plus-circle.svg'
+import { gridStyle } from './template.css'
+
 const MOCK_TEMPLATES = [
-  {
-    id: 1,
-    title: '정규 수업 템플릿1',
-    classCount: 4,
-    classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'],
-  },
-  {
-    id: 2,
-    title: '보강 수업 템플릿',
-    classCount: 4,
-    classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'],
-  },
-  {
-    id: 3,
-    title: '방학 특강 템플릿',
-    classCount: 4,
-    classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'],
-  },
-  {
-    id: 4,
-    title: '정규 수업 템플릿2',
-    classCount: 4,
-    classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'],
-  },
-  {
-    id: 5,
-    title: '시험대비 클리닉 템플릿',
-    classCount: 4,
-    classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'],
-  },
+  { id: 1, title: '정규 수업 템플릿1', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
+  { id: 2, title: '보강 수업 템플릿', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
+  { id: 3, title: '방학 특강 템플릿', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
+  { id: 4, title: '정규 수업 템플릿2', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
+  { id: 5, title: '시험대비 클리닉 템플릿', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
 ]
 
+type DeleteTarget = {
+  id: number
+  title: string
+  classCount: number
+}
+
 export default function TemplatePage() {
+  const router = useRouter()
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null)
+
   return (
-    <div>
-      <Text variant="display" as="h1">
-        수업 템플릿
-      </Text>
+    <>
+      <Text variant="display" as="h1">수업 템플릿</Text>
       <div className={gridStyle}>
         {MOCK_TEMPLATES.map((template) => (
           <TemplateCard
             key={template.id}
             {...template}
-            onDelete={(id) => console.log('delete', id)}
+            onDelete={(id) => setDeleteTarget({ id, title: template.title, classCount: template.classCount })}
           />
         ))}
+        <AddCard
+          icon={<PlusCircleIcon width={36} height={36} />}
+          label="템플릿 추가"
+          onClick={() => router.push('/template/new')}
+        />
       </div>
-    </div>
+      <DeleteConfirmModal
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => {
+          console.log('delete', deleteTarget?.id)
+          setDeleteTarget(null)
+        }}
+        templateName={deleteTarget?.title ?? ''}
+        classCount={deleteTarget?.classCount ?? 0}
+      />
+    </>
   )
 }

--- a/src/app/(main)/template/template.css.ts
+++ b/src/app/(main)/template/template.css.ts
@@ -4,7 +4,7 @@ export const gridStyle = style({
   display: 'grid',
   gridTemplateColumns: 'repeat(3, 1fr)',
   gap: '20px',
-  marginTop: '32px',
+  marginTop: '60px',
   '@media': {
     'screen and (max-width: 1279px)': {
       gridTemplateColumns: 'repeat(2, 1fr)',

--- a/src/app/(main)/template/template.css.ts
+++ b/src/app/(main)/template/template.css.ts
@@ -1,0 +1,16 @@
+import { style } from '@vanilla-extract/css'
+
+export const gridStyle = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gap: '20px',
+  marginTop: '32px',
+  '@media': {
+    'screen and (max-width: 1279px)': {
+      gridTemplateColumns: 'repeat(2, 1fr)',
+    },
+    'screen and (max-width: 767px)': {
+      gridTemplateColumns: 'repeat(1, 1fr)',
+    },
+  },
+})

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,8 @@
   
   body {
     font-family: 'Pretendard', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
   
   img, video {

--- a/src/assets/icons/icon-plus-circle.svg
+++ b/src/assets/icons/icon-plus-circle.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 8V16M8 12H16M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/AddCard/AddCard.css.ts
+++ b/src/components/common/AddCard/AddCard.css.ts
@@ -1,0 +1,38 @@
+import { style } from '@vanilla-extract/css'
+import { colors } from '@/styles/tokens/colors'
+import { fontStyles } from '@/styles/tokens/typography'
+
+export const addCardStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '8px',
+  backgroundColor: colors.gray50,
+  border: `1px solid ${colors.gray100}`,
+  borderRadius: '16px',
+  padding: '24px',
+  cursor: 'pointer',
+  width: '100%',
+  height: '100%',
+  transition: 'background-color 0.2s',
+  selectors: {
+    '&:hover:not(:disabled)': {
+      backgroundColor: colors.primary50,
+    },
+    '&:disabled': {
+      cursor: 'not-allowed',
+      color: colors.gray300,
+    },
+  },
+  color: colors.gray300,
+})
+
+export const descriptionStyle = style({
+  color: colors.gray300,
+  fontSize: fontStyles.bodyMd.fontSize,
+  fontWeight: fontStyles.bodyMd.fontWeight,
+  textAlign: 'center',
+  lineHeight: '140%',
+  letterSpacing: '-0.03em',
+})

--- a/src/components/common/AddCard/AddCard.tsx
+++ b/src/components/common/AddCard/AddCard.tsx
@@ -1,0 +1,19 @@
+import { ButtonHTMLAttributes, ReactNode } from 'react'
+import { addCardStyle, descriptionStyle } from './AddCard.css'
+import Text from '@/components/common/Text'
+
+interface AddCardProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon?: ReactNode
+  label: string
+  description?: string
+}
+
+export default function AddCard({ icon, label, description, ...props }: AddCardProps) {
+  return (
+    <button className={addCardStyle} {...props}>
+      {icon}
+      <Text variant="titleSm" color="gray300">{label}</Text>
+      {description && <p className={descriptionStyle}>{description}</p>}
+    </button>
+  )
+}

--- a/src/components/common/AddCard/index.ts
+++ b/src/components/common/AddCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AddCard'

--- a/src/components/common/Button/Button.css.ts
+++ b/src/components/common/Button/Button.css.ts
@@ -9,6 +9,7 @@ export const buttonRecipe = recipe({
     gap: '4px',
     border: 'none',
     borderRadius: '8px',
+    boxSizing: 'border-box',
     cursor: 'pointer',
     fontFamily: 'Pretendard, sans-serif',
     transition: 'background-color 0.2s, opacity 0.2s',
@@ -53,8 +54,16 @@ export const buttonRecipe = recipe({
         color: colors.gray700,
         outline: `1px solid ${colors.gray100}`,
         selectors: {
-          '&:hover:not(:disabled)': { backgroundColor: colors.primary50, color: colors.primary500, outline: `1px solid ${colors.primary500}` },
-          '&:active:not(:disabled)': { backgroundColor: colors.primary50, color: colors.primary500, outline: `1px solid ${colors.primary500}` },
+          '&:hover:not(:disabled)': {
+            backgroundColor: colors.primary50,
+            color: colors.primary500,
+            outline: `1px solid ${colors.primary500}`,
+          },
+          '&:active:not(:disabled)': {
+            backgroundColor: colors.primary50,
+            color: colors.primary500,
+            outline: `1px solid ${colors.primary500}`,
+          },
           '&:disabled': { color: colors.gray100, outline: `1px solid ${colors.gray100}` },
         },
       },
@@ -70,8 +79,8 @@ export const buttonRecipe = recipe({
     },
     size: {
       sm: { padding: '8px 12px', fontSize: '14px', fontWeight: '500' },
-      md: { padding: '12px 128px', fontSize: '14px', fontWeight: '600' },
-      lg: { padding: '16px 120px', fontSize: '16px', fontWeight: '600' },
+      md: { padding: '12px 24px', fontSize: '14px', fontWeight: '600' },
+      lg: { padding: '16px 24px', fontSize: '16px', fontWeight: '600' },
     },
     fullWidth: {
       true: { width: '100%' },

--- a/src/components/common/Modal/Modal.css.ts
+++ b/src/components/common/Modal/Modal.css.ts
@@ -1,0 +1,43 @@
+import { style } from '@vanilla-extract/css'
+import { recipe } from '@vanilla-extract/recipes'
+import { colors } from '@/styles/tokens/colors'
+
+export const overlayStyle = style({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  backgroundColor: 'rgba(0, 0, 0, 0.2)',
+  backdropFilter: 'blur(4px)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+})
+
+export const modalRecipe = recipe({
+  base: {
+    backgroundColor: colors.white,
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  variants: {
+    size: {
+      sm: {
+        width: '420px',
+        borderRadius: '16px',
+        padding: '24px',
+      },
+      md: {
+        width: '640px',
+        borderRadius: '24px',
+        padding: '48px',
+      },
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+})

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { overlayStyle, modalRecipe } from './Modal.css'
+
+interface ModalProps {
+  isOpen: boolean
+  onClose: () => void
+  size?: 'sm' | 'md'
+  children: ReactNode
+}
+
+export default function Modal({ isOpen, onClose, size = 'md', children }: ModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className={overlayStyle} onClick={onClose}>
+      <div
+        className={modalRecipe({ size })}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/Modal/index.ts
+++ b/src/components/common/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Modal'


### PR DESCRIPTION
## 이슈 넘버

- close #7
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 수업 템플릿 목록 페이지 구현 (3열 반응형 그리드)
- [x] TemplateCard 컴포넌트 구현 — 카드 클릭 시 수정 페이지 라우팅, 삭제 아이콘
- [x] AddCard 공통 컴포넌트 구현 — 세로형 추가 카드
- [x] 템플릿 삭제 확인 모달 구현 — 사용 중인 반 수 표시
- [x] Pretendard 폰트 렌더링 개선 — `-webkit-font-smoothing: antialiased` 적용