### PR TITLE
feat: 학생/반 관리 - 반별 보기 탭 구현

### DIFF
--- a/src/app/(main)/management/_components/ClassCard/ClassCard.css.ts
+++ b/src/app/(main)/management/_components/ClassCard/ClassCard.css.ts
@@ -1,0 +1,58 @@
+import { style } from '@vanilla-extract/css'
+import { colors } from '@/styles/tokens/colors'
+import { fontStyles } from '@/styles/tokens/typography'
+
+export const cardStyle = style({
+  backgroundColor: colors.white,
+  border: `1px solid ${colors.gray100}`,
+  borderRadius: '16px',
+  padding: '24px',
+  cursor: 'pointer',
+  transition: 'background-color 0.2s',
+  display: 'flex',
+  flexDirection: 'column',
+  selectors: {
+    '&:hover': {
+      backgroundColor: colors.primary50,
+    },
+  },
+})
+
+export const headerStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginBottom: '16px',
+})
+
+export const chipGroupStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+})
+
+export const dateStyle = style({
+  fontSize: fontStyles.bodyMd.fontSize,
+  fontWeight: fontStyles.bodyMd.fontWeight,
+  color: colors.gray300,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+})
+
+export const infoGroupStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  marginTop: '12px',
+})
+
+export const infoRowStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  fontSize: fontStyles.bodyMd.fontSize,
+  fontWeight: fontStyles.bodyMd.fontWeight,
+  color: colors.gray500,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+})

--- a/src/app/(main)/management/_components/ClassCard/ClassCard.tsx
+++ b/src/app/(main)/management/_components/ClassCard/ClassCard.tsx
@@ -1,0 +1,62 @@
+import { useRouter } from 'next/navigation'
+import Text from '@/components/common/Text'
+import Chip from '@/components/common/Chip'
+import CalendarIcon from '@/assets/icons/icon-calendar.svg'
+import UsersIcon from '@/assets/icons/icon-users.svg'
+import {
+  cardStyle,
+  headerStyle,
+  chipGroupStyle,
+  dateStyle,
+  infoGroupStyle,
+  infoRowStyle,
+} from './ClassCard.css'
+
+interface ClassCardProps {
+  id: number
+  academyName: string
+  name: string
+  schedule: string
+  studentCount: number
+  isEnded?: boolean
+  startDate?: string
+  endDate?: string
+}
+
+export default function ClassCard({
+  id,
+  academyName,
+  name,
+  schedule,
+  studentCount,
+  isEnded,
+  startDate,
+  endDate,
+}: ClassCardProps) {
+  const router = useRouter()
+
+  return (
+    <div className={cardStyle} onClick={() => router.push(`/management/${id}`)}>
+      <div className={headerStyle}>
+        <div className={chipGroupStyle}>
+          <Chip variant="default" label={academyName} />
+          {isEnded && <Chip variant="ended" label="종료" />}
+        </div>
+        {isEnded && startDate && endDate && (
+          <span className={dateStyle}>{startDate} – {endDate}</span>
+        )}
+      </div>
+      <Text variant="headingLg" as="h3">{name}</Text>
+      <div className={infoGroupStyle}>
+        <div className={infoRowStyle}>
+          <CalendarIcon width={16} height={16} />
+          {schedule}
+        </div>
+        <div className={infoRowStyle}>
+          <UsersIcon width={16} height={16} />
+          {studentCount}명
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/management/management.css.ts
+++ b/src/app/(main)/management/management.css.ts
@@ -1,0 +1,44 @@
+import { style } from '@vanilla-extract/css'
+import { colors } from '@/styles/tokens/colors'
+import { fontStyles } from '@/styles/tokens/typography'
+
+const tabBase = {
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  fontSize: fontStyles.headingLg.fontSize,
+  fontWeight: fontStyles.headingLg.fontWeight,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+  padding: 0,
+} as const
+
+export const tabContainerStyle = style({
+  display: 'flex',
+  gap: '32px',
+  marginTop: '60px',
+  marginBottom: '24px',
+})
+
+export const tabStyle = style([tabBase, {
+  color: colors.gray300,
+}])
+
+export const tabActiveStyle = style([tabBase, {
+  color: colors.gray900,
+}])
+
+export const gridStyle = style({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gridAutoRows: 'minmax(190px, auto)',
+    gap: '20px',
+    '@media': {
+      'screen and (max-width: 1279px)': {
+        gridTemplateColumns: 'repeat(2, 1fr)',
+      },
+      'screen and (max-width: 767px)': {
+        gridTemplateColumns: 'repeat(1, 1fr)',
+      },
+    },
+  })

--- a/src/app/(main)/management/page.tsx
+++ b/src/app/(main)/management/page.tsx
@@ -1,3 +1,86 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Suspense, useState } from 'react'
+import Text from '@/components/common/Text'
+import AddCard from '@/components/common/AddCard'
+import Dropdown from '@/components/common/Dropdown'
+import ClassCard from './_components/ClassCard/ClassCard'
+import PlusCircleIcon from '@/assets/icons/icon-plus-circle.svg'
+import { tabStyle, tabActiveStyle, tabContainerStyle, gridStyle } from './management.css'
+
+const FILTER_OPTIONS = [
+  { label: '전체', value: 'all' },
+  { label: '진행 중', value: 'active' },
+  { label: '종료', value: 'ended' },
+]
+
+const MOCK_CLASSES = [
+  { id: 1, academyName: '엘리에듀학원', name: '미적분 A반', schedule: '수·금 14:00 – 16:00', studentCount: 25, isEnded: false },
+  { id: 2, academyName: '엘리에듀학원', name: '미적분 A반', schedule: '수·금 14:00 – 16:00', studentCount: 25, isEnded: false },
+  { id: 3, academyName: '엘리에듀학원', name: '미적분 A반', schedule: '수·금 14:00 – 16:00', studentCount: 25, isEnded: true, startDate: '26.02.14', endDate: '26.07.23' },
+]
+
+function ManagementContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const tab = searchParams.get('tab') ?? 'class'
+  const [filter, setFilter] = useState('all')
+
+  const filteredClasses = MOCK_CLASSES.filter((cls) => {
+    if (filter === 'active') return !cls.isEnded
+    if (filter === 'ended') return cls.isEnded
+    return true
+  })
+
+  return (
+    <>
+      <Text variant="display" as="h1">학생·반 관리</Text>
+      <div className={tabContainerStyle}>
+        <button
+          className={tab === 'class' ? tabActiveStyle : tabStyle}
+          onClick={() => router.push('/management?tab=class')}
+        >
+          반별 보기
+        </button>
+        <button
+          className={tab === 'students' ? tabActiveStyle : tabStyle}
+          onClick={() => router.push('/management?tab=students')}
+        >
+          전체 학생
+        </button>
+      </div>
+      {tab === 'class' && (
+        <>
+          <div style={{ marginBottom: '20px' }}>
+            <Dropdown
+              options={FILTER_OPTIONS}
+              value={filter}
+              onChange={setFilter}
+              placeholder="전체"
+            />
+          </div>
+          <div className={gridStyle}>
+            {filteredClasses.map((cls) => (
+              <ClassCard key={cls.id} {...cls} />
+            ))}
+            <AddCard
+              icon={<PlusCircleIcon width={36} height={36} />}
+              label="반 추가"
+              onClick={() => console.log('반 추가')}
+            />
+          </div>
+        </>
+      )}
+      {tab === 'students' && <div>{/* 전체 학생 */}</div>}
+    </>
+  )
+}
+
 export default function ManagementPage() {
-    return <div>학생·반 관리</div>
-  }
+  return (
+    <Suspense>
+      <ManagementContent />
+    </Suspense>
+  )
+}

--- a/src/components/common/Dropdown/Dropdown.css.ts
+++ b/src/components/common/Dropdown/Dropdown.css.ts
@@ -1,0 +1,85 @@
+import { style } from '@vanilla-extract/css'
+import { colors } from '@/styles/tokens/colors'
+import { fontStyles } from '@/styles/tokens/typography'
+
+const itemTypography = {
+  fontSize: fontStyles.titleSm.fontSize,
+  fontWeight: fontStyles.titleSm.fontWeight,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+} as const
+
+export const containerStyle = style({
+  position: 'relative',
+  display: 'inline-block',
+})
+
+export const triggerStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '32px',
+  backgroundColor: colors.white,
+  border: `1px solid ${colors.gray200}`,
+  borderRadius: '8px',
+  padding: '8px 16px',
+  cursor: 'pointer',
+  color: colors.gray700,
+  transition: 'border-color 0.2s, color 0.2s',
+  ...itemTypography,
+  selectors: {
+    '&:hover': {
+      backgroundColor: colors.primary50,
+    },
+  },
+})
+
+export const triggerActiveStyle = style({
+  color: colors.primary500,
+})
+
+export const menuStyle = style({
+  position: 'absolute',
+  top: 'calc(100% + 4px)',
+  left: 0,
+  backgroundColor: colors.white,
+  border: `1px solid ${colors.gray200}`,
+  borderRadius: '8px',
+  zIndex: 100,
+  minWidth: '100%',
+  overflow: 'hidden',
+  padding: '8px 0',
+})
+
+export const menuLabelStyle = style({
+  padding: '8px 16px',
+  color: colors.gray300,
+  ...itemTypography,
+})
+
+export const optionStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  padding: '8px 16px',
+  cursor: 'pointer',
+  color: colors.gray700,
+  transition: 'background-color 0.15s',
+  ...itemTypography,
+  selectors: {
+    '&:hover': {
+      backgroundColor: colors.gray50,
+    },
+  },
+})
+
+export const optionSelectedStyle = style({
+  color: colors.primary500,
+})
+
+export const chevronStyle = style({
+  transition: 'transform 0.2s ease',
+  flexShrink: 0,
+})
+
+export const chevronOpenStyle = style({
+  transform: 'rotate(180deg)',
+})

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import ChevronDownIcon from '@/assets/icons/icon-chevron-down.svg'
+import {
+  containerStyle,
+  triggerStyle,
+  triggerActiveStyle,
+  menuStyle,
+  menuLabelStyle,
+  optionStyle,
+  optionSelectedStyle,
+  chevronStyle,
+  chevronOpenStyle,
+} from './Dropdown.css'
+
+interface DropdownOption {
+  label: string
+  value: string
+}
+
+interface DropdownProps {
+  options: DropdownOption[]
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  menuLabel?: string
+}
+
+export default function Dropdown({
+  options,
+  value,
+  onChange,
+  placeholder = '선택',
+  menuLabel,
+}: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const selectedOption = options.find((opt) => opt.value === value)
+  const isSelected = !!selectedOption
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  return (
+    <div className={containerStyle} ref={containerRef}>
+      <button
+        className={`${triggerStyle}${isSelected ? ` ${triggerActiveStyle}` : ''}`}
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        {selectedOption ? selectedOption.label : placeholder}
+        <ChevronDownIcon
+          width={16}
+          height={16}
+          className={`${chevronStyle}${isOpen ? ` ${chevronOpenStyle}` : ''}`}
+        />
+      </button>
+      {isOpen && (
+        <div className={menuStyle}>
+          {menuLabel && <div className={menuLabelStyle}>{menuLabel}</div>}
+          {options.map((opt) => (
+            <div
+              key={opt.value}
+              className={`${optionStyle}${opt.value === value ? ` ${optionSelectedStyle}` : ''}`}
+              onClick={() => {
+                onChange(opt.value)
+                setIsOpen(false)
+              }}
+            >
+              {opt.label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/common/Dropdown/index.ts
+++ b/src/components/common/Dropdown/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Dropdown'


### PR DESCRIPTION
## 이슈 넘버

- close #11
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 학생·반 관리 페이지 레이아웃 구현 — 반별 보기 / 전체 학생 탭 (URL 기반)
- [x] ClassCard 컴포넌트 구현 — 학원명 chip, 종료 chip, 수업 요일/시간, 학생 수
- [x] 반 목록 3열 반응형 그리드
- [x] 진행 중 / 종료 / 전체 필터 드롭다운
- [x] AddCard 연결 (반 추가)
- [x] Dropdown 공통 컴포넌트 구현