### PR TITLE
refactor: P3 리팩토링

### DIFF
--- a/src/app/(main)/lesson/[id]/page.tsx
+++ b/src/app/(main)/lesson/[id]/page.tsx
@@ -27,35 +27,17 @@ import {
   headerButtonGroupStyle,
 } from './lessonDetail.css'
 import MessagePreview from './_components/MessagePreview/MessagePreview'
-
-const MOCK_TEMPLATES = [
-  { id: 1, name: '정규 수업 템플릿' },
-  { id: 2, name: '클리닉 템플릿' },
-  { id: 3, name: '보강 템플릿' },
-]
-
-const MOCK_COMMON_ITEMS = [
-  { id: 1, label: '오늘 학습 내용' },
-  { id: 2, label: '다음 시간 범위' },
-  { id: 3, label: '클리닉 안내' },
-  { id: 4, label: '이번 주 과제' },
-]
-
-const MOCK_STUDENTS = Array.from({ length: 6 }, (_, i) => ({
-  id: i + 1,
-  name: '홍길동',
-  attendance: null as '출석' | '지각' | '결석' | null,
-  homework: null as '완료' | '미완료' | null,
-  answerNote: null as '완료' | '미완료' | null,
-  score: '',
-  memo: '',
-}))
+import {
+  MOCK_LESSON_TEMPLATES,
+  MOCK_COMMON_ITEMS,
+  MOCK_LESSON_STUDENTS,
+} from '@/mocks/lesson'
 
 export default function LessonDetailPage() {
   const router = useRouter()
   const [selectedTemplateId, setSelectedTemplateId] = useState(1)
   const [commonValues, setCommonValues] = useState<Record<number, string>>({})
-  const [students, setStudents] = useState(MOCK_STUDENTS)
+  const [students, setStudents] = useState(MOCK_LESSON_STUDENTS)
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
 
   const handleExcelDownload = () => {
@@ -130,7 +112,7 @@ export default function LessonDetailPage() {
           </Text>
         </div>
         <div className={templateChipGroupStyle}>
-          {MOCK_TEMPLATES.map((t) => (
+          {MOCK_LESSON_TEMPLATES.map((t) => (
             <button
               key={t.id}
               className={templateChipRecipe({ selected: selectedTemplateId === t.id })}

--- a/src/app/(main)/lesson/_components/AddLessonModal/AddLessonModal.tsx
+++ b/src/app/(main)/lesson/_components/AddLessonModal/AddLessonModal.tsx
@@ -19,12 +19,7 @@ import {
   radioSelectedStyle,
   actionsStyle,
 } from './AddLessonModal.css'
-
-const MOCK_CLASSES = [
-  { id: 1, name: '미적분 B반', academyName: '엘리에듀학원', schedule: '수·금' },
-  { id: 2, name: '토요 클리닉', academyName: '엘리에듀학원', schedule: '수·금' },
-  { id: 3, name: '기하 A반', academyName: '엘리에듀학원', schedule: '수·금' },
-]
+import { MOCK_LESSON_CLASSES } from '@/mocks/lesson'
 
 interface AddLessonModalProps {
   isOpen: boolean
@@ -55,7 +50,7 @@ export default function AddLessonModal({
         </Text>
       </div>
       <div className={classListStyle}>
-        {MOCK_CLASSES.map((cls) => {
+        {MOCK_LESSON_CLASSES.map((cls) => {
           const isSelected = selectedId === cls.id
           return (
             <div

--- a/src/app/(main)/lesson/page.tsx
+++ b/src/app/(main)/lesson/page.tsx
@@ -20,41 +20,9 @@ import {
   navButtonStyle,
   weekNavStyle,
 } from './lesson.css'
+import { MOCK_LESSONS } from '@/mocks/lesson'
 
 const DAYS_KO = ['월', '화', '수', '목', '금', '토', '일']
-
-const MOCK_LESSONS = [
-  {
-    id: 1,
-    academyName: '엘리에듀학원',
-    templateName: '정규 수업 템플릿',
-    className: '미적분 A반',
-    progress: 100,
-    totalStudents: 29,
-    inputCount: 29,
-    isDone: true,
-  },
-  {
-    id: 2,
-    academyName: '엘리에듀학원',
-    templateName: '겨울방학 특강 템플릿',
-    className: '미적분 A반',
-    progress: 0,
-    totalStudents: 29,
-    inputCount: 0,
-    isDone: false,
-  },
-  {
-    id: 3,
-    academyName: '엘리에듀학원',
-    templateName: '겨울방학 특강 템플릿',
-    className: '미적분 A반',
-    progress: 0,
-    totalStudents: 29,
-    inputCount: 0,
-    isDone: false,
-  },
-]
 
 export default function LessonPage() {
   const router = useRouter()

--- a/src/app/(main)/management/[id]/_components/AddStudentModal/AddStudentModal.tsx
+++ b/src/app/(main)/management/[id]/_components/AddStudentModal/AddStudentModal.tsx
@@ -7,6 +7,8 @@ import Button from '@/components/common/Button'
 import Modal from '@/components/common/Modal'
 import CheckIcon from '@/assets/icons/icon-check.svg'
 import { colors } from '@/styles/tokens/colors'
+import useToggleArray from '@/hooks/useToggleArray'
+import { MOCK_CANDIDATE_STUDENTS } from '@/mocks/management'
 import {
   titleStyle,
   searchWrapperStyle,
@@ -19,14 +21,6 @@ import {
   emptyStyle,
 } from './AddStudentModal.css'
 
-const MOCK_STUDENTS = [
-  { id: 1, name: '홍길동', phone: '010-1234-5678' },
-  { id: 2, name: '김철수', phone: '010-2345-6789' },
-  { id: 3, name: '이영희', phone: '010-3456-7890' },
-  { id: 4, name: '박민준', phone: '010-4567-8901' },
-  { id: 5, name: '최지은', phone: '010-5678-9012' },
-]
-
 interface AddStudentModalProps {
   isOpen: boolean
   onClose: () => void
@@ -35,21 +29,15 @@ interface AddStudentModalProps {
 
 export default function AddStudentModal({ isOpen, onClose, onConfirm }: AddStudentModalProps) {
   const [search, setSearch] = useState('')
-  const [selectedIds, setSelectedIds] = useState<number[]>([])
+  const { items: selectedIds, toggle: toggleSelect, reset: resetIds } = useToggleArray<number>()
 
-  const filtered = MOCK_STUDENTS.filter((s) =>
+  const filtered = MOCK_CANDIDATE_STUDENTS.filter((s) =>
     s.name.includes(search) || s.phone.includes(search)
   )
 
-  const toggleSelect = (id: number) => {
-    setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
-    )
-  }
-
   const handleClose = () => {
     setSearch('')
-    setSelectedIds([])
+    resetIds()
     onClose()
   }
 

--- a/src/app/(main)/management/[id]/page.tsx
+++ b/src/app/(main)/management/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { colors } from '@/styles/tokens/colors'
+import useDisclosure from '@/hooks/useDisclosure'
 import Text from '@/components/common/Text'
 import Button from '@/components/common/Button'
 import ClassInfoTable from './_components/ClassInfoTable/ClassInfoTable'
@@ -16,33 +17,15 @@ import AddStudentModal from './_components/AddStudentModal/AddStudentModal'
 import ConfirmModal from '@/components/common/ConfirmModal'
 import ClassFormModal from '../_components/ClassFormModal/ClassFormModal'
 import { tdStyle } from '../_components/StudentTable/StudentTable.css'
-
-const MOCK_CLASS = {
-  id: 1,
-  name: '미적분 A반',
-  academyName: '엘리에듀학원',
-  schedule: '화·금',
-  time: '16:00 - 17:30',
-  template: '정규 수업 템플릿',
-}
-
-const MOCK_STUDENTS = Array.from({ length: 10 }, (_, i) => ({
-  id: i + 1,
-  name: '홍길동',
-  studentPhone: '010-1234-5678',
-  parentPhone: '010-1234-5678',
-  memo: '',
-  completionRate: 47,
-  remaining: 3,
-}))
+import { MOCK_CLASS, MOCK_CLASS_STUDENTS } from '@/mocks/management'
 
 export default function ClassDetailPage() {
   const router = useRouter()
-  const [isAddStudentOpen, setIsAddStudentOpen] = useState(false)
+  const addStudent = useDisclosure()
   const [deleteStudentTarget, setDeleteStudentTarget] = useState<number | null>(null)
-  const [isEndClassOpen, setIsEndClassOpen] = useState(false)
-  const [isDeleteClassOpen, setIsDeleteClassOpen] = useState(false)
-  const [isEditClassOpen, setIsEditClassOpen] = useState(false)
+  const endClass = useDisclosure()
+  const deleteClass = useDisclosure()
+  const editClass = useDisclosure()
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '60px' }}>
@@ -68,14 +51,14 @@ export default function ClassDetailPage() {
             size="sm"
             leftIcon={<EditIcon width={14} height={14} />}
             style={{ height: '28px' }}
-            onClick={() => setIsEditClassOpen(true)}
+            onClick={editClass.open}
           >
             수정
           </Button>
 
           <ClassFormModal
-            isOpen={isEditClassOpen}
-            onClose={() => setIsEditClassOpen(false)}
+            isOpen={editClass.isOpen}
+            onClose={editClass.close}
             onConfirm={(data) => console.log('반 수정', data)}
             mode="edit"
             defaultValues={{
@@ -103,19 +86,19 @@ export default function ClassDetailPage() {
             variant="primary"
             size="sm"
             leftIcon={<PlusIcon width={20} height={20} />}
-            onClick={() => setIsAddStudentOpen(true)}
+            onClick={addStudent.open}
           >
             학생 등록
           </Button>
 
           <AddStudentModal
-            isOpen={isAddStudentOpen}
-            onClose={() => setIsAddStudentOpen(false)}
+            isOpen={addStudent.isOpen}
+            onClose={addStudent.close}
             onConfirm={(ids) => console.log('추가할 학생 ids:', ids)}
           />
         </div>
         <StudentTable
-          students={MOCK_STUDENTS}
+          students={MOCK_CLASS_STUDENTS}
           middleColumn={{
             header: '메모',
             render: (student) => <td className={tdStyle}>{student.memo ?? ''}</td>,
@@ -130,14 +113,14 @@ export default function ClassDetailPage() {
           title="반 종료"
           description="학기가 끝났거나 더 이상 수업이 없다면 반을 종료할 수 있어요."
           buttonLabel="반 종료하기"
-          onConfirm={() => setIsEndClassOpen(true)}
+          onConfirm={endClass.open}
         />
         <DangerSection
           variant="delete"
           title="반 삭제"
           description="반을 삭제하면 학생 배정이 해제되지만, 수업 기록은 그대로 남아요."
           buttonLabel="반 삭제하기"
-          onConfirm={() => setIsDeleteClassOpen(true)}
+          onConfirm={deleteClass.open}
         />
 
         {/* 모달들 */}
@@ -148,18 +131,18 @@ export default function ClassDetailPage() {
             console.log('학생 삭제', deleteStudentTarget)
             setDeleteStudentTarget(null)
           }}
-          title={`'${MOCK_STUDENTS.find((s) => s.id === deleteStudentTarget)?.name}' 학생을 ${MOCK_CLASS.name}에서 제거할까요?`}
+          title={`'${MOCK_CLASS_STUDENTS.find((s) => s.id === deleteStudentTarget)?.name}' 학생을 ${MOCK_CLASS.name}에서 제거할까요?`}
           descriptions={['반에서 제거되지만 학생 정보는 그대로 남아요.']}
           confirmLabel="제거"
           confirmVariant="danger"
         />
 
         <ConfirmModal
-          isOpen={isEndClassOpen}
-          onClose={() => setIsEndClassOpen(false)}
+          isOpen={endClass.isOpen}
+          onClose={endClass.close}
           onConfirm={() => {
             console.log('반 종료')
-            setIsEndClassOpen(false)
+            endClass.close()
           }}
           title={`'${MOCK_CLASS.name}'을 종료할까요?`}
           descriptions={['종료 후에는 수업 입력이 불가능해요.']}
@@ -168,11 +151,11 @@ export default function ClassDetailPage() {
         />
 
         <ConfirmModal
-          isOpen={isDeleteClassOpen}
-          onClose={() => setIsDeleteClassOpen(false)}
+          isOpen={deleteClass.isOpen}
+          onClose={deleteClass.close}
           onConfirm={() => {
             console.log('반 삭제')
-            setIsDeleteClassOpen(false)
+            deleteClass.close()
           }}
           title={`'${MOCK_CLASS.name}'을 삭제할까요?`}
           descriptions={['학생 배정이 해제되지만, 수업 기록은 그대로 남아요.']}

--- a/src/app/(main)/management/_components/AddStudentFormModal/AddStudentFormModal.tsx
+++ b/src/app/(main)/management/_components/AddStudentFormModal/AddStudentFormModal.tsx
@@ -5,6 +5,8 @@ import Text from '@/components/common/Text'
 import Input from '@/components/common/Input'
 import Button from '@/components/common/Button'
 import Modal from '@/components/common/Modal'
+import useToggleArray from '@/hooks/useToggleArray'
+import { MOCK_CLASS_NAMES } from '@/mocks/management'
 import {
   fieldGroupStyle,
   fieldStyle,
@@ -13,8 +15,6 @@ import {
   classChipRecipe,
   actionsStyle,
 } from './AddStudentFormModal.css'
-
-const MOCK_CLASSES = ['미적분 A반', '미적분 B반', '미적분 C반', '기하 A반', '기하 B반']
 
 interface AddStudentFormModalProps {
   isOpen: boolean
@@ -35,19 +35,13 @@ export default function AddStudentFormModal({
   const [name, setName] = useState('')
   const [studentPhone, setStudentPhone] = useState('')
   const [parentPhone, setParentPhone] = useState('')
-  const [selectedClasses, setSelectedClasses] = useState<string[]>([])
-
-  const toggleClass = (cls: string) => {
-    setSelectedClasses((prev) =>
-      prev.includes(cls) ? prev.filter((c) => c !== cls) : [...prev, cls]
-    )
-  }
+  const { items: selectedClasses, toggle: toggleClass, reset: resetClasses } = useToggleArray<string>()
 
   const handleClose = () => {
     setName('')
     setStudentPhone('')
     setParentPhone('')
-    setSelectedClasses([])
+    resetClasses()
     onClose()
   }
 
@@ -90,7 +84,7 @@ export default function AddStudentFormModal({
         <div className={fieldStyle}>
           <span className={labelStyle}>소속 반</span>
           <div className={classChipGroupStyle}>
-            {MOCK_CLASSES.map((cls) => (
+            {MOCK_CLASS_NAMES.map((cls) => (
               <button
                 key={cls}
                 className={classChipRecipe({ selected: selectedClasses.includes(cls) })}

--- a/src/app/(main)/management/_components/ClassFormModal/ClassFormModal.tsx
+++ b/src/app/(main)/management/_components/ClassFormModal/ClassFormModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import Text from '@/components/common/Text'
 import Input from '@/components/common/Input'
+import useToggleArray from '@/hooks/useToggleArray'
 import Button from '@/components/common/Button'
 import Modal from '@/components/common/Modal'
 import {
@@ -46,7 +47,7 @@ export default function ClassFormModal({
 }: ClassFormModalProps) {
   const [academyName, setAcademyName] = useState('')
   const [name, setName] = useState('')
-  const [selectedDays, setSelectedDays] = useState<number[]>([])
+  const { items: selectedDays, toggle: toggleDay, set: setSelectedDays, reset: resetDays } = useToggleArray<number>()
 
   useEffect(() => {
     if (isOpen && defaultValues) {
@@ -56,16 +57,10 @@ export default function ClassFormModal({
     }
   }, [isOpen, defaultValues])
 
-  const toggleDay = (value: number) => {
-    setSelectedDays((prev) =>
-      prev.includes(value) ? prev.filter((d) => d !== value) : [...prev, value]
-    )
-  }
-
   const handleClose = () => {
     setAcademyName('')
     setName('')
-    setSelectedDays([])
+    resetDays()
     onClose()
   }
 

--- a/src/app/(main)/management/page.tsx
+++ b/src/app/(main)/management/page.tsx
@@ -3,6 +3,8 @@
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Suspense, useState } from 'react'
 import Text from '@/components/common/Text'
+import useDisclosure from '@/hooks/useDisclosure'
+import { MOCK_CLASSES, MOCK_ALL_STUDENTS } from '@/mocks/management'
 import Button from '@/components/common/Button'
 import PlusIcon from '@/assets/icons/icon-plus.svg'
 import UploadIcon from '@/assets/icons/icon-upload.svg'
@@ -30,44 +32,6 @@ const FILTER_OPTIONS = [
   { label: '종료', value: 'ended' },
 ]
 
-const MOCK_CLASSES = [
-  {
-    id: 1,
-    academyName: '엘리에듀학원',
-    name: '미적분 A반',
-    schedule: '수·금 14:00 – 16:00',
-    studentCount: 25,
-    isEnded: false,
-  },
-  {
-    id: 2,
-    academyName: '엘리에듀학원',
-    name: '미적분 A반',
-    schedule: '수·금 14:00 – 16:00',
-    studentCount: 25,
-    isEnded: false,
-  },
-  {
-    id: 3,
-    academyName: '엘리에듀학원',
-    name: '미적분 A반',
-    schedule: '수·금 14:00 – 16:00',
-    studentCount: 25,
-    isEnded: true,
-    startDate: '26.02.14',
-    endDate: '26.07.23',
-  },
-]
-
-const MOCK_ALL_STUDENTS = Array.from({ length: 10 }, (_, i) => ({
-  id: i + 1,
-  name: '홍길동',
-  studentPhone: '010-1234-5678',
-  parentPhone: '010-1234-5678',
-  completionRate: i === 1 ? 87 : i === 2 ? 17 : 47,
-  remaining: i === 1 ? 1 : i === 2 ? 5 : 3,
-  classes: ['미적분 A반', '미적분 B반'],
-}))
 
 function ManagementContent() {
   const router = useRouter()
@@ -81,9 +45,9 @@ function ManagementContent() {
     return true
   })
 
-  const [isAddClassOpen, setIsAddClassOpen] = useState(false)
-  const [isAddStudentOpen, setIsAddStudentOpen] = useState(false)
-  const [isBulkUploadOpen, setIsBulkUploadOpen] = useState(false)
+  const addClass = useDisclosure()
+  const addStudent = useDisclosure()
+  const bulkUpload = useDisclosure()
   const [deleteStudentTarget, setDeleteStudentTarget] = useState<number | null>(null)
 
   return (
@@ -110,7 +74,7 @@ function ManagementContent() {
               variant="secondary"
               size="sm"
               leftIcon={<UploadIcon width={20} height={20} />}
-              onClick={() => setIsBulkUploadOpen(true)}
+              onClick={bulkUpload.open}
             >
               일괄 등록
             </Button>
@@ -118,7 +82,7 @@ function ManagementContent() {
               variant="primary"
               size="sm"
               leftIcon={<PlusIcon width={20} height={20} />}
-              onClick={() => setIsAddStudentOpen(true)}
+              onClick={addStudent.open}
             >
               학생 등록
             </Button>
@@ -142,12 +106,12 @@ function ManagementContent() {
             <AddCard
               icon={<PlusCircleIcon width={36} height={36} />}
               label="반 추가"
-              onClick={() => setIsAddClassOpen(true)}
+              onClick={addClass.open}
             />
 
             <ClassFormModal
-              isOpen={isAddClassOpen}
-              onClose={() => setIsAddClassOpen(false)}
+              isOpen={addClass.isOpen}
+              onClose={addClass.close}
               onConfirm={(data) => {
                 console.log('새 반 추가:', data)
               }}
@@ -159,13 +123,13 @@ function ManagementContent() {
       {tab === 'students' && (
         <>
           <BulkUploadModal
-            isOpen={isBulkUploadOpen}
-            onClose={() => setIsBulkUploadOpen(false)}
+            isOpen={bulkUpload.isOpen}
+            onClose={bulkUpload.close}
             onConfirm={(file) => console.log('업로드', file)}
           />
           <AddStudentFormModal
-            isOpen={isAddStudentOpen}
-            onClose={() => setIsAddStudentOpen(false)}
+            isOpen={addStudent.isOpen}
+            onClose={addStudent.close}
             onConfirm={(data) => {
               console.log('새 학생 추가:', data)
             }}

--- a/src/app/(main)/template/new/page.tsx
+++ b/src/app/(main)/template/new/page.tsx
@@ -15,22 +15,7 @@ import {
 } from '../template-form.css'
 import SaveIcon from '@/assets/icons/icon-save.svg'
 import type { TemplateItem } from '../_types/template'
-
-const INITIAL_COMMON_ITEMS: TemplateItem[] = [
-  { id: 'c-1', label: '오늘 학습 내용', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
-  { id: 'c-2', label: '다음 시간 범위', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
-  { id: 'c-3', label: '클리닉 안내', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
-  { id: 'c-4', label: '이번 주 과제', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
-  { id: 'c-5', label: '다음 시험 일정', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
-]
-
-const INITIAL_INDIVIDUAL_ITEMS: TemplateItem[] = [
-  { id: 'i-1', label: '출결 *', isActive: true, isInMessage: true, locked: true, category: 'individual', itemType: 'completion' },
-  { id: 'i-2', label: '시험 점수', isActive: true, isInMessage: true, category: 'individual', itemType: 'number' },
-  { id: 'i-3', label: '과제', isActive: false, isInMessage: true, category: 'individual', itemType: 'completion' },
-  { id: 'i-4', label: '반평균', isActive: true, isInMessage: true, category: 'individual', itemType: 'number' },
-  { id: 'i-5', label: '오답노트', isActive: true, isInMessage: true, category: 'individual', itemType: 'completion' },
-]
+import { INITIAL_COMMON_ITEMS, INITIAL_INDIVIDUAL_ITEMS } from '@/mocks/template'
 
 const INITIAL_MESSAGE_ORDER = [
   ...INITIAL_COMMON_ITEMS.map((i) => i.id),

--- a/src/app/(main)/template/page.tsx
+++ b/src/app/(main)/template/page.tsx
@@ -8,14 +8,7 @@ import TemplateCard from './_components/TemplateCard/TemplateCard'
 import DeleteConfirmModal from './_components/DeleteConfirmModal/DeleteConfirmModal'
 import PlusCircleIcon from '@/assets/icons/icon-plus-circle.svg'
 import { gridStyle } from './template.css'
-
-const MOCK_TEMPLATES = [
-  { id: 1, title: '정규 수업 템플릿1', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
-  { id: 2, title: '보강 수업 템플릿', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
-  { id: 3, title: '방학 특강 템플릿', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
-  { id: 4, title: '정규 수업 템플릿2', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
-  { id: 5, title: '시험대비 클리닉 템플릿', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
-]
+import { MOCK_TEMPLATES } from '@/mocks/template'
 
 type DeleteTarget = {
   id: number

--- a/src/hooks/useDisclosure.ts
+++ b/src/hooks/useDisclosure.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react'
+
+export default function useDisclosure(initialOpen = false) {
+  const [isOpen, setIsOpen] = useState(initialOpen)
+
+  return {
+    isOpen,
+    open: () => setIsOpen(true),
+    close: () => setIsOpen(false),
+  }
+}

--- a/src/hooks/useToggleArray.ts
+++ b/src/hooks/useToggleArray.ts
@@ -1,0 +1,15 @@
+import { useState, type Dispatch, type SetStateAction } from 'react'
+
+export default function useToggleArray<T>(initialValue: T[] = []) {
+  const [items, setItems] = useState<T[]>(initialValue)
+
+  const toggle = (item: T) => {
+    setItems((prev) =>
+      prev.includes(item) ? prev.filter((i) => i !== item) : [...prev, item]
+    )
+  }
+
+  const reset = () => setItems(initialValue)
+
+  return { items, toggle, set: setItems as Dispatch<SetStateAction<T[]>>, reset }
+}

--- a/src/mocks/lesson.ts
+++ b/src/mocks/lesson.ts
@@ -1,0 +1,64 @@
+import type { LessonStudent } from '@/types/lessonStudent'
+
+export const MOCK_LESSONS = [
+  {
+    id: 1,
+    academyName: '엘리에듀학원',
+    templateName: '정규 수업 템플릿',
+    className: '미적분 A반',
+    progress: 100,
+    totalStudents: 29,
+    inputCount: 29,
+    isDone: true,
+  },
+  {
+    id: 2,
+    academyName: '엘리에듀학원',
+    templateName: '겨울방학 특강 템플릿',
+    className: '미적분 A반',
+    progress: 0,
+    totalStudents: 29,
+    inputCount: 0,
+    isDone: false,
+  },
+  {
+    id: 3,
+    academyName: '엘리에듀학원',
+    templateName: '겨울방학 특강 템플릿',
+    className: '미적분 A반',
+    progress: 0,
+    totalStudents: 29,
+    inputCount: 0,
+    isDone: false,
+  },
+]
+
+export const MOCK_LESSON_TEMPLATES = [
+  { id: 1, name: '정규 수업 템플릿' },
+  { id: 2, name: '클리닉 템플릿' },
+  { id: 3, name: '보강 템플릿' },
+]
+
+export const MOCK_COMMON_ITEMS = [
+  { id: 1, label: '오늘 학습 내용' },
+  { id: 2, label: '다음 시간 범위' },
+  { id: 3, label: '클리닉 안내' },
+  { id: 4, label: '이번 주 과제' },
+]
+
+export const MOCK_LESSON_STUDENTS: LessonStudent[] = Array.from({ length: 6 }, (_, i) => ({
+  id: i + 1,
+  name: '홍길동',
+  attendance: null,
+  homework: null,
+  answerNote: null,
+  score: '',
+  memo: '',
+}))
+
+// AddLessonModal에서 수업을 추가할 수 있는 반 목록
+export const MOCK_LESSON_CLASSES = [
+  { id: 1, name: '미적분 B반', academyName: '엘리에듀학원', schedule: '수·금' },
+  { id: 2, name: '토요 클리닉', academyName: '엘리에듀학원', schedule: '수·금' },
+  { id: 3, name: '기하 A반', academyName: '엘리에듀학원', schedule: '수·금' },
+]

--- a/src/mocks/management.ts
+++ b/src/mocks/management.ts
@@ -1,0 +1,71 @@
+import type { Student } from '@/types/student'
+
+export const MOCK_CLASSES = [
+  {
+    id: 1,
+    academyName: '엘리에듀학원',
+    name: '미적분 A반',
+    schedule: '수·금 14:00 – 16:00',
+    studentCount: 25,
+    isEnded: false,
+  },
+  {
+    id: 2,
+    academyName: '엘리에듀학원',
+    name: '미적분 A반',
+    schedule: '수·금 14:00 – 16:00',
+    studentCount: 25,
+    isEnded: false,
+  },
+  {
+    id: 3,
+    academyName: '엘리에듀학원',
+    name: '미적분 A반',
+    schedule: '수·금 14:00 – 16:00',
+    studentCount: 25,
+    isEnded: true,
+    startDate: '26.02.14',
+    endDate: '26.07.23',
+  },
+]
+
+export const MOCK_ALL_STUDENTS: Student[] = Array.from({ length: 10 }, (_, i) => ({
+  id: i + 1,
+  name: '홍길동',
+  studentPhone: '010-1234-5678',
+  parentPhone: '010-1234-5678',
+  completionRate: i === 1 ? 87 : i === 2 ? 17 : 47,
+  remaining: i === 1 ? 1 : i === 2 ? 5 : 3,
+  classes: ['미적분 A반', '미적분 B반'],
+}))
+
+export const MOCK_CLASS = {
+  id: 1,
+  name: '미적분 A반',
+  academyName: '엘리에듀학원',
+  schedule: '화·금',
+  time: '16:00 - 17:30',
+  template: '정규 수업 템플릿',
+}
+
+export const MOCK_CLASS_STUDENTS: Student[] = Array.from({ length: 10 }, (_, i) => ({
+  id: i + 1,
+  name: '홍길동',
+  studentPhone: '010-1234-5678',
+  parentPhone: '010-1234-5678',
+  completionRate: 47,
+  remaining: 3,
+  memo: '',
+}))
+
+// AddStudentModal에서 반에 추가할 수 있는 학생 목록
+export const MOCK_CANDIDATE_STUDENTS = [
+  { id: 1, name: '홍길동', phone: '010-1234-5678' },
+  { id: 2, name: '김철수', phone: '010-2345-6789' },
+  { id: 3, name: '이영희', phone: '010-3456-7890' },
+  { id: 4, name: '박민준', phone: '010-4567-8901' },
+  { id: 5, name: '최지은', phone: '010-5678-9012' },
+]
+
+// AddStudentFormModal에서 학생을 배정할 반 이름 목록
+export const MOCK_CLASS_NAMES = ['미적분 A반', '미적분 B반', '미적분 C반', '기하 A반', '기하 B반']

--- a/src/mocks/template.ts
+++ b/src/mocks/template.ts
@@ -1,0 +1,25 @@
+import type { TemplateItem } from '@/app/(main)/template/_types/template'
+
+export const MOCK_TEMPLATES = [
+  { id: 1, title: '정규 수업 템플릿1', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
+  { id: 2, title: '보강 수업 템플릿', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
+  { id: 3, title: '방학 특강 템플릿', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
+  { id: 4, title: '정규 수업 템플릿2', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
+  { id: 5, title: '시험대비 클리닉 템플릿', classCount: 4, classList: ['미적분 A반', '미적분 B반', '미적분 C반', '미적분 D반'] },
+]
+
+export const INITIAL_COMMON_ITEMS: TemplateItem[] = [
+  { id: 'c-1', label: '오늘 학습 내용', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
+  { id: 'c-2', label: '다음 시간 범위', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
+  { id: 'c-3', label: '클리닉 안내', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
+  { id: 'c-4', label: '이번 주 과제', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
+  { id: 'c-5', label: '다음 시험 일정', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
+]
+
+export const INITIAL_INDIVIDUAL_ITEMS: TemplateItem[] = [
+  { id: 'i-1', label: '출결 *', isActive: true, isInMessage: true, locked: true, category: 'individual', itemType: 'completion' },
+  { id: 'i-2', label: '시험 점수', isActive: true, isInMessage: true, category: 'individual', itemType: 'number' },
+  { id: 'i-3', label: '과제', isActive: false, isInMessage: true, category: 'individual', itemType: 'completion' },
+  { id: 'i-4', label: '반평균', isActive: true, isInMessage: true, category: 'individual', itemType: 'number' },
+  { id: 'i-5', label: '오답노트', isActive: true, isInMessage: true, category: 'individual', itemType: 'completion' },
+]


### PR DESCRIPTION
## 이슈 넘버

- close #29 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 타입 시스템 및 데이터 관리 개선
- 도메인 타입 분리: Student와 LessonStudent 타입을 명확히 구분하여 도메인 간 간섭 제거
- Mock 데이터 중앙화: 각 페이지에 인라인으로 정의되어 있던 데이터를 src/mocks로 추출 (lesson, management, template 별 분리)
- [x] 비즈니스 로직 추상화
- useDisclosure: 모달 및 드로어의 Open/Close 상태 관리 로직 공통화
- useToggleArray: 토글 로직을 훅으로 분리하여 가독성 및 재사용성 향상
- [x] 컴포넌트 최적화
- 6개의 page.tsx와 2개의 모달 컴포넌트 내부에 존재하던 불필요한 상수와 중복 로직 제거
- 컴포넌트는 View 렌더링에 집중하고, 데이터와 상태 관리는 외부(Mocks, Hooks)에서 주입받는 구조로 개선