### PR TITLE
refactor: P4 리팩토링

### DIFF
--- a/src/app/(main)/lesson/[id]/_components/MessagePreview/MessagePreview.tsx
+++ b/src/app/(main)/lesson/[id]/_components/MessagePreview/MessagePreview.tsx
@@ -4,6 +4,7 @@ import Dropdown from '@/components/common/Dropdown'
 import CloseIcon from '@/assets/icons/icon-close.svg'
 import { generateStudentMessage } from '@/lib/generateStudentMessage'
 import type { LessonStudent } from '@/types/lessonStudent'
+import { DEFAULT_LESSON_CONTEXT } from '@/hooks/useLessonDetail'
 import {
   backdrop, drawer, drawerClosing, header, content,
   dropdownTrigger, messagePreview, closeButtonStyle,
@@ -59,7 +60,7 @@ export default function MessagePreview({
           />
 
           <div className={messagePreview}>
-            {selectedStudent ? generateStudentMessage(selectedStudent, commonValues) : ''}
+            {selectedStudent ? generateStudentMessage(selectedStudent, commonValues, DEFAULT_LESSON_CONTEXT) : ''}
           </div>
         </div>
       </div>

--- a/src/app/(main)/lesson/[id]/page.tsx
+++ b/src/app/(main)/lesson/[id]/page.tsx
@@ -1,9 +1,6 @@
 'use client'
 
-import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import * as XLSX from 'xlsx'
-import { generateStudentMessage } from '@/lib/generateStudentMessage'
 import Text from '@/components/common/Text'
 import Button from '@/components/common/Button'
 import ArrowLeftIcon from '@/assets/icons/icon-arrow-left.svg'
@@ -27,74 +24,42 @@ import {
   headerButtonGroupStyle,
 } from './lessonDetail.css'
 import MessagePreview from './_components/MessagePreview/MessagePreview'
-import {
-  MOCK_LESSON_TEMPLATES,
-  MOCK_COMMON_ITEMS,
-  MOCK_LESSON_STUDENTS,
-} from '@/mocks/lesson'
+import { MOCK_LESSON_TEMPLATES, MOCK_COMMON_ITEMS } from '@/mocks/lesson'
+import useLessonDetail, { DEFAULT_LESSON_CONTEXT } from '@/hooks/useLessonDetail'
 
 export default function LessonDetailPage() {
   const router = useRouter()
-  const [selectedTemplateId, setSelectedTemplateId] = useState(1)
-  const [commonValues, setCommonValues] = useState<Record<number, string>>({})
-  const [students, setStudents] = useState(MOCK_LESSON_STUDENTS)
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-
-  const handleExcelDownload = () => {
-    const commonRows = MOCK_COMMON_ITEMS.map((item) => [item.label, commonValues[item.id] || ''])
-    const studentRows = students.map((s) => [
-      s.name,
-      s.attendance ?? '미입력',
-      s.homework ?? '미입력',
-      s.answerNote ?? '미입력',
-      s.score || '0',
-      s.memo || '',
-    ])
-
-    const ws = XLSX.utils.aoa_to_sheet([
-      ['2월 20일(금) 미적분 A반 수업 결과'],
-      [],
-      ['공통 내용'],
-      ...commonRows,
-      [],
-      ['개별 내용'],
-      ['이름', '출결', '숙제', '오답노트', '시험 점수', '메모'],
-      ...studentRows,
-    ])
-
-    const wsMessages = XLSX.utils.aoa_to_sheet([
-      ['이름', '문자 내용'],
-      ...students.map((s) => [s.name, generateStudentMessage(s, commonValues)]),
-    ])
-
-    const wb = XLSX.utils.book_new()
-    XLSX.utils.book_append_sheet(wb, ws, '수업 결과')
-    XLSX.utils.book_append_sheet(wb, wsMessages, '문자 내용')
-    XLSX.writeFile(wb, '수업결과.xlsx')
-  }
-
-  const inputCount = students.filter(
-    (s) => s.attendance !== null && s.homework !== null && s.answerNote !== null && s.score !== ''
-  ).length
+  const {
+    selectedTemplateId,
+    setSelectedTemplateId,
+    commonValues,
+    setCommonValues,
+    students,
+    setStudents,
+    messagePreview,
+    inputCount,
+    handleExcelDownload,
+  } = useLessonDetail()
 
   return (
     <div className={pageStyle}>
       {/* 헤더 */}
       <div className={headerStyle}>
         <div className={headerLeftStyle}>
-          <button
-            onClick={() => router.back()}
-            className={backButtonStyle}
-          >
+          <button onClick={() => router.back()} className={backButtonStyle}>
             <ArrowLeftIcon width={24} height={24} />
           </button>
-
           <Text variant="display" as="h1">
-            2월 20일(금) 미적분 A반
+            {DEFAULT_LESSON_CONTEXT.lessonDate} {DEFAULT_LESSON_CONTEXT.className}
           </Text>
         </div>
         <div className={headerButtonGroupStyle}>
-          <Button variant="secondary" size="sm" leftIcon={<DownloadIcon width={20} height={20} />} onClick={handleExcelDownload}>
+          <Button
+            variant="secondary"
+            size="sm"
+            leftIcon={<DownloadIcon width={20} height={20} />}
+            onClick={handleExcelDownload}
+          >
             엑셀 다운로드
           </Button>
           <Button variant="primary" size="sm" leftIcon={<SaveIcon width={20} height={20} />}>
@@ -147,15 +112,15 @@ export default function LessonDetailPage() {
           variant="primary"
           size="sm"
           leftIcon={<MessageIcon width={20} height={20} />}
-          onClick={() => setIsDrawerOpen(true)}
+          onClick={messagePreview.open}
         >
           문자 미리보기
         </Button>
       </div>
 
       <MessagePreview
-        isOpen={isDrawerOpen}
-        onClose={() => setIsDrawerOpen(false)}
+        isOpen={messagePreview.isOpen}
+        onClose={messagePreview.close}
         commonValues={commonValues}
         students={students}
       />

--- a/src/app/(main)/template/[id]/page.tsx
+++ b/src/app/(main)/template/[id]/page.tsx
@@ -1,7 +1,11 @@
 'use client'
 
+import { use } from 'react'
+import { useRouter } from 'next/navigation'
 import Text from '@/components/common/Text'
 import Button from '@/components/common/Button'
+import ArrowLeftIcon from '@/assets/icons/icon-arrow-left.svg'
+import SaveIcon from '@/assets/icons/icon-save.svg'
 import TemplateName from '../_components/TemplateName/TemplateName'
 import ContentSection from '../_components/ContentSection/ContentSection'
 import MessageSettings from '../_components/MessageSettings/MessageSettings'
@@ -11,26 +15,30 @@ import {
   leftSectionStyle,
   rightSectionStyle,
   sectionBoxStyle,
+  formHeaderStyle,
+  formHeaderLeftStyle,
+  formBackButtonStyle,
 } from '../template-form.css'
-import SaveIcon from '@/assets/icons/icon-save.svg'
 import useTemplateEditor from '@/hooks/useTemplateEditor'
+import { MOCK_TEMPLATES } from '@/mocks/template'
 
-export default function TemplateNewPage() {
-  const editor = useTemplateEditor()
+export default function TemplateEditPage({ params }: { params: Promise<{ id: string }> }) {
+  const router = useRouter()
+  const { id } = use(params)
+  const template = MOCK_TEMPLATES.find((t) => t.id === Number(id))
+  const editor = useTemplateEditor({ name: template?.title })
 
   return (
     <>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginBottom: '32px',
-        }}
-      >
-        <Text variant="display" as="h1">
-          수업 템플릿 생성
-        </Text>
+      <div className={formHeaderStyle}>
+        <div className={formHeaderLeftStyle}>
+          <button className={formBackButtonStyle} onClick={() => router.back()}>
+            <ArrowLeftIcon width={24} height={24} />
+          </button>
+          <Text variant="display" as="h1">
+            수업 템플릿 수정
+          </Text>
+        </div>
         <Button variant="primary" size="sm" leftIcon={<SaveIcon width={16} height={16} />}>
           저장
         </Button>

--- a/src/app/(main)/template/template-form.css.ts
+++ b/src/app/(main)/template/template-form.css.ts
@@ -25,3 +25,25 @@ export const sectionBoxStyle = style({
   borderRadius: '16px',
   padding: '32px',
 })
+
+export const formHeaderStyle = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: '32px',
+})
+
+export const formHeaderLeftStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '12px',
+})
+
+export const formBackButtonStyle = style({
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: colors.gray500,
+  display: 'flex',
+  alignItems: 'center',
+})

--- a/src/hooks/useLessonDetail.ts
+++ b/src/hooks/useLessonDetail.ts
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import type { LessonStudent } from '@/types/lessonStudent'
+import type { MessageContext } from '@/lib/generateStudentMessage'
+import { exportLessonExcel } from '@/lib/exportExcel'
+import { MOCK_COMMON_ITEMS, MOCK_LESSON_STUDENTS } from '@/mocks/lesson'
+import useDisclosure from './useDisclosure'
+
+// API 연동 전까지 페이지 수준에서 주입되는 수업 컨텍스트
+export const DEFAULT_LESSON_CONTEXT: MessageContext = {
+  academyName: '엘리에듀학원',
+  teacherName: '윤준용',
+  className: '미적분 A반',
+  lessonDate: '2월 20일(금)',
+}
+
+export default function useLessonDetail() {
+  const [selectedTemplateId, setSelectedTemplateId] = useState(1)
+  const [commonValues, setCommonValues] = useState<Record<number, string>>({})
+  const [students, setStudents] = useState<LessonStudent[]>(MOCK_LESSON_STUDENTS)
+  const messagePreview = useDisclosure()
+
+  const inputCount = students.filter(
+    (s) =>
+      s.attendance !== null &&
+      s.homework !== null &&
+      s.answerNote !== null &&
+      s.score !== '',
+  ).length
+
+  const handleExcelDownload = () => {
+    exportLessonExcel({
+      title: `${DEFAULT_LESSON_CONTEXT.lessonDate} ${DEFAULT_LESSON_CONTEXT.className} 수업 결과`,
+      commonItems: MOCK_COMMON_ITEMS,
+      commonValues,
+      students,
+      context: DEFAULT_LESSON_CONTEXT,
+    })
+  }
+
+  return {
+    selectedTemplateId,
+    setSelectedTemplateId,
+    commonValues,
+    setCommonValues,
+    students,
+    setStudents,
+    messagePreview,
+    inputCount,
+    handleExcelDownload,
+  }
+}

--- a/src/hooks/useTemplateEditor.ts
+++ b/src/hooks/useTemplateEditor.ts
@@ -1,0 +1,109 @@
+import { useMemo, useState } from 'react'
+import type { TemplateItem } from '@/app/(main)/template/_types/template'
+import { INITIAL_COMMON_ITEMS, INITIAL_INDIVIDUAL_ITEMS } from '@/mocks/template'
+
+interface InitialData {
+  name?: string
+  commonItems?: TemplateItem[]
+  individualItems?: TemplateItem[]
+}
+
+export default function useTemplateEditor(initial: InitialData = {}) {
+  const initCommon = initial.commonItems ?? INITIAL_COMMON_ITEMS
+  const initIndividual = initial.individualItems ?? INITIAL_INDIVIDUAL_ITEMS
+
+  const [templateName, setTemplateName] = useState(initial.name ?? '')
+  const [commonItems, setCommonItems] = useState<TemplateItem[]>(initCommon)
+  const [individualItems, setIndividualItems] = useState<TemplateItem[]>(initIndividual)
+  const [messageOrder, setMessageOrder] = useState<string[]>([
+    ...initCommon.map((i) => i.id),
+    ...initIndividual.map((i) => i.id),
+  ])
+
+  const allItemsMap = useMemo(() => {
+    const map = new Map<string, TemplateItem>()
+    for (const item of commonItems) map.set(item.id, item)
+    for (const item of individualItems) map.set(item.id, item)
+    return map
+  }, [commonItems, individualItems])
+
+  const handleToggleCommonItem = (id: string) => {
+    setCommonItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, isActive: !item.isActive } : item))
+    )
+  }
+
+  const handleDeleteCommonItem = (id: string) => {
+    setCommonItems((prev) => prev.filter((item) => item.id !== id))
+    setMessageOrder((prev) => prev.filter((orderId) => orderId !== id))
+  }
+
+  const handleAddCommonItem = (): string => {
+    const newId = 'c-' + Date.now()
+    setCommonItems((prev) => [
+      ...prev,
+      { id: newId, label: '', isActive: true, isInMessage: true, category: 'common', itemType: 'inline' },
+    ])
+    setMessageOrder((prev) => [...prev, newId])
+    return newId
+  }
+
+  const handleUpdateCommonItem = (id: string, label: string) => {
+    setCommonItems((prev) => prev.map((item) => (item.id === id ? { ...item, label } : item)))
+  }
+
+  const handleToggleIndividualItem = (id: string) => {
+    setIndividualItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, isActive: !item.isActive } : item))
+    )
+  }
+
+  const handleDeleteIndividualItem = (id: string) => {
+    setIndividualItems((prev) => prev.filter((item) => item.id !== id))
+    setMessageOrder((prev) => prev.filter((orderId) => orderId !== id))
+  }
+
+  const handleAddIndividualItem = (label: string, type: string, choices?: string[]) => {
+    const newId = 'i-' + Date.now()
+    setIndividualItems((prev) => [
+      ...prev,
+      {
+        id: newId,
+        label,
+        isActive: true,
+        isInMessage: true,
+        category: 'individual',
+        itemType: type as TemplateItem['itemType'],
+        choices,
+      },
+    ])
+    setMessageOrder((prev) => [...prev, newId])
+  }
+
+  const handleMessagePreviewToggle = (id: string) => {
+    const toggle = (prev: TemplateItem[]) =>
+      prev.map((item) => (item.id === id ? { ...item, isInMessage: !item.isInMessage } : item))
+    setCommonItems(toggle)
+    setIndividualItems(toggle)
+  }
+
+  const handleMessageReorder = (newOrder: string[]) => setMessageOrder(newOrder)
+
+  return {
+    templateName,
+    setTemplateName,
+    commonItems,
+    individualItems,
+    messageOrder,
+    allItemsMap,
+    handleToggleCommonItem,
+    handleDeleteCommonItem,
+    handleAddCommonItem,
+    handleUpdateCommonItem,
+    handleToggleIndividualItem,
+    handleDeleteIndividualItem,
+    handleAddIndividualItem,
+    handleMessagePreviewToggle,
+    handleMessageReorder,
+  }
+}

--- a/src/lib/exportExcel.ts
+++ b/src/lib/exportExcel.ts
@@ -1,0 +1,55 @@
+import * as XLSX from 'xlsx'
+import type { LessonStudent } from '@/types/lessonStudent'
+import { generateStudentMessage } from './generateStudentMessage'
+
+interface LessonExportOptions {
+  title: string
+  commonItems: { id: number; label: string }[]
+  commonValues: Record<number, string>
+  students: LessonStudent[]
+  context: {
+    academyName: string
+    teacherName: string
+    className: string
+    lessonDate: string
+  }
+}
+
+export function exportLessonExcel({
+  title,
+  commonItems,
+  commonValues,
+  students,
+  context,
+}: LessonExportOptions) {
+  const commonRows = commonItems.map((item) => [item.label, commonValues[item.id] || ''])
+  const studentRows = students.map((s) => [
+    s.name,
+    s.attendance ?? '미입력',
+    s.homework ?? '미입력',
+    s.answerNote ?? '미입력',
+    s.score || '0',
+    s.memo || '',
+  ])
+
+  const ws = XLSX.utils.aoa_to_sheet([
+    [title],
+    [],
+    ['공통 내용'],
+    ...commonRows,
+    [],
+    ['개별 내용'],
+    ['이름', '출결', '숙제', '오답노트', '시험 점수', '메모'],
+    ...studentRows,
+  ])
+
+  const wsMessages = XLSX.utils.aoa_to_sheet([
+    ['이름', '문자 내용'],
+    ...students.map((s) => [s.name, generateStudentMessage(s, commonValues, context)]),
+  ])
+
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, ws, '수업 결과')
+  XLSX.utils.book_append_sheet(wb, wsMessages, '문자 내용')
+  XLSX.writeFile(wb, '수업결과.xlsx')
+}

--- a/src/lib/generateStudentMessage.ts
+++ b/src/lib/generateStudentMessage.ts
@@ -1,11 +1,19 @@
 import type { LessonStudent } from '@/types/lessonStudent'
 
+export interface MessageContext {
+  academyName: string
+  teacherName: string
+  className: string
+  lessonDate: string
+}
+
 export function generateStudentMessage(
   student: LessonStudent,
   commonValues: Record<number, string>,
+  context: MessageContext,
 ): string {
-  return `안녕하세요, 엘리에듀학원 윤준용 강사입니다.
-미적분 A반 2월 20일(금) 수업 결과입니다.
+  return `안녕하세요, ${context.academyName} ${context.teacherName} 강사입니다.
+${context.className} ${context.lessonDate} 수업 결과입니다.
 
 • 오늘 학습 내용: ${commonValues[1] || '-'}
 • 다음 시간 범위: ${commonValues[2] || '-'}


### PR DESCRIPTION
## 이슈 넘버

- close #31 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 템플릿 수정 기능 추가
- [x] 도메인 로직 리팩토링
- useTemplateEditor: 템플릿 생성 및 수정 페이지에서 공통으로 사용하는 폼 상태와 핸들러를 추출하여 중복 코드 제거
- useLessonDetail: lesson/[id] 페이지의 복잡한 상태(공통 내용, 학생 데이터, 미리보기 등)를 전면 추출하여 View와 로직 분리
- exportLessonExcel: 엑셀 다운로드 로직을 src/lib/exportExcel.ts로 유틸리티화
- [x] 메시지 생성 컨텍스트 최적화
- MessageContext 도입: 문자 생성 시 학원명, 강사명 등 가변 인자를 context 객체로 주입받도록 개선
- DEFAULT_LESSON_CONTEXT: useLessonDetail.ts 내에 선언하여 API 연동 시 환경 설정 값을 한곳에서 관리할 수 있도록 단일화