### PR TITLE
feat: refresh_token 저장 및 로그아웃/토큰 갱신 API 연동

### DIFF
--- a/src/components/common/Sidebar/Sidebar.tsx
+++ b/src/components/common/Sidebar/Sidebar.tsx
@@ -29,14 +29,8 @@ const NAV_ITEMS = [
 
 export default function Sidebar() {
   const pathname = usePathname()
-  
-  const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false)
 
-  const handleLogout = () => {
-    if (confirm('로그아웃 하시겠습니까?')) {
-      auth.logout()
-    }
-  }
+  const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false)
 
   return (
     <aside className={sidebarStyle}>
@@ -67,7 +61,9 @@ export default function Sidebar() {
       <LogoutConfirmModal
         isOpen={isLogoutModalOpen}
         onClose={() => setIsLogoutModalOpen(false)}
-        onConfirm={() => auth.logout()}
+        onConfirm={async () => {
+          await auth.logout()
+        }}
       />
     </aside>
   )

--- a/src/lib/api/axiosInstance.ts
+++ b/src/lib/api/axiosInstance.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { deleteCookie } from 'cookies-next'
+import { deleteCookie, getCookie, setCookie } from 'cookies-next'
 
 const axiosInstance = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_API_URL}/api/v1`,
@@ -9,17 +9,97 @@ const axiosInstance = axios.create({
   },
 })
 
-axiosInstance.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      const isLoginRequest = error.config.url?.includes('/auth/login')
-      if (!isLoginRequest) {
-        localStorage.removeItem('accessToken')
-        deleteCookie('accessToken', { path: '/' })
-        window.location.href = '/login'
+// 요청 인터셉터: 액세스 토큰 자동 부착
+axiosInstance.interceptors.request.use(
+  (config) => {
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('accessToken')
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`
       }
     }
+    return config
+  },
+  (error) => Promise.reject(error)
+)
+
+// 응답 인터셉터: 401 시 silent refresh 후 재시도
+let isRefreshing = false
+let failedQueue: Array<{
+  resolve: (token: string) => void
+  reject: (error: unknown) => void
+}> = []
+
+const processQueue = (error: unknown, token: string | null) => {
+  failedQueue.forEach((prom) => {
+    if (error) prom.reject(error)
+    else prom.resolve(token!)
+  })
+  failedQueue = []
+}
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config
+
+    const isAuthRequest =
+      originalRequest.url?.includes('/auth/login') ||
+      originalRequest.url?.includes('/auth/refresh')
+
+    // 인증 관련 요청은 인터셉터에서 처리하지 않음
+    if (isAuthRequest) return Promise.reject(error)
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        // 이미 refresh 중이면 대기열에 추가
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject })
+        }).then((token) => {
+          originalRequest.headers.Authorization = `Bearer ${token}`
+          return axiosInstance(originalRequest)
+        })
+      }
+
+      originalRequest._retry = true
+      isRefreshing = true
+
+      try {
+        const refreshToken = getCookie('refreshToken')
+        if (!refreshToken) throw new Error('No refresh token')
+
+        const { data } = await axiosInstance.post('/auth/refresh', {
+          refresh_token: refreshToken,
+        })
+
+        const newAccessToken = data.data.access_token
+        const newRefreshToken = data.data.refresh_token
+
+        // 토큰 갱신
+        localStorage.setItem('accessToken', newAccessToken)
+        setCookie('accessToken', newAccessToken, { maxAge: 60 * 60 * 24 * 7, path: '/' })
+        setCookie('refreshToken', newRefreshToken, { maxAge: 60 * 60 * 24 * 7, path: '/' })
+
+        processQueue(null, newAccessToken)
+
+        // 원래 요청 재시도
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`
+        return axiosInstance(originalRequest)
+      } catch (refreshError) {
+        processQueue(refreshError, null)
+
+        // refresh 실패 → 로그아웃
+        localStorage.removeItem('accessToken')
+        deleteCookie('accessToken', { path: '/' })
+        deleteCookie('refreshToken', { path: '/' })
+        window.location.href = '/login'
+
+        return Promise.reject(refreshError)
+      } finally {
+        isRefreshing = false
+      }
+    }
+
     return Promise.reject(error)
   }
 )

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,33 +1,71 @@
 import axiosInstance from '@/lib/api/axiosInstance'
-import { setCookie, deleteCookie } from 'cookies-next'
+import { setCookie, deleteCookie, getCookie } from 'cookies-next'
 
 interface LoginRequest {
   email: string
   password: string
 }
 
+interface AuthTokens {
+  access_token: string
+  refresh_token: string
+}
+
 interface LoginResponse {
-  accessToken: string
+  success: boolean
+  data: AuthTokens & {
+    user: {
+      id: number
+      email: string
+      name: string
+      created_at: string
+    }
+  }
+}
+
+interface RefreshResponse {
+  success: boolean
+  data: AuthTokens
+}
+
+const setTokens = (accessToken: string, refreshToken: string) => {
+  setCookie('accessToken', accessToken, { maxAge: 60 * 60 * 24 * 7, path: '/' })
+  setCookie('refreshToken', refreshToken, { maxAge: 60 * 60 * 24 * 7, path: '/' })
+  localStorage.setItem('accessToken', accessToken)
+}
+
+const clearTokens = () => {
+  deleteCookie('accessToken', { path: '/' })
+  deleteCookie('refreshToken', { path: '/' })
+  localStorage.removeItem('accessToken')
 }
 
 export const auth = {
-  async login({ email, password }: LoginRequest): Promise<LoginResponse> {
+  async login({ email, password }: LoginRequest) {
     const { data } = await axiosInstance.post<LoginResponse>('/auth/login', { email, password })
-
-    // 미들웨어용 쿠키 저장
-    setCookie('accessToken', data.accessToken, {
-      maxAge: 60 * 60 * 24 * 7, // 7일
-      path: '/',
-    })
-    // Axios 인터셉터용 localStorage 저장
-    localStorage.setItem('accessToken', data.accessToken)
-
-    return data
+    setTokens(data.data.access_token, data.data.refresh_token)
+    return data.data.user
   },
 
-  logout() {
-    localStorage.removeItem('accessToken')
-    deleteCookie('accessToken', { path: '/' })
-    window.location.href = '/login'
+  async logout() {
+    const refreshToken = getCookie('refreshToken')
+    try {
+      await axiosInstance.post('/auth/logout', { refresh_token: refreshToken })
+    } finally {
+      // API 실패해도 클라이언트 토큰은 반드시 삭제
+      clearTokens()
+      window.location.href = '/login'
+    }
+  },
+
+  async refresh() {
+    const refreshToken = getCookie('refreshToken')
+    const { data } = await axiosInstance.post<RefreshResponse>('/auth/refresh', {
+      refresh_token: refreshToken,
+    })
+    setTokens(data.data.access_token, data.data.refresh_token)
+    return data.data.access_token
   },
 }
+
+export { setTokens, clearTokens }


### PR DESCRIPTION
## 이슈 넘버

- close #35 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] auth.ts
- 로그인 응답 타입 수정 (camelCase → snake_case)
- `refresh_token` 쿠키 저장 추가
- `setTokens` / `clearTokens` 헬퍼로 토큰 저장/삭제 로직 중앙화
- `auth.logout()` API 연동 — 서버에서 refresh_token 무효화 후 클라이언트 토큰 삭제
- `auth.refresh()` 추가

- [x] axiosInstance.ts
- 401 응답 시 silent refresh 후 원래 요청 자동 재시도
- `failedQueue`로 동시 다발 401 요청 중복 refresh 방지
- refresh 실패 시 로그아웃 처리

- [x] Sidebar.tsx
- 미사용 `handleLogout` 함수 제거