### PR TITLE
feat: 학생 상세 정보 모달 UI 구현 및 API 연동

### DIFF
--- a/src/app/(main)/management/[id]/page.tsx
+++ b/src/app/(main)/management/[id]/page.tsx
@@ -16,6 +16,7 @@ import PlusIcon from '@/assets/icons/icon-plus.svg'
 import AddStudentModal from './_components/AddStudentModal/AddStudentModal'
 import ConfirmModal from '@/components/common/ConfirmModal'
 import ClassFormModal from '../_components/ClassFormModal/ClassFormModal'
+import StudentDetailModal from '../_components/StudentDetailModal/StudentDetailModal'
 
 import { MOCK_CLASS, MOCK_CLASS_STUDENTS } from '@/mocks/management'
 
@@ -26,6 +27,7 @@ export default function ClassDetailPage() {
   const endClass = useDisclosure()
   const deleteClass = useDisclosure()
   const editClass = useDisclosure()
+  const [selectedStudentId, setSelectedStudentId] = useState<number | null>(null)
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '60px' }}>
@@ -106,6 +108,7 @@ export default function ClassDetailPage() {
             },
           ]}
           onDelete={(id) => setDeleteStudentTarget(id)}
+          onRowClick={(id) => setSelectedStudentId(id)}
         />
       </section>
 
@@ -165,6 +168,10 @@ export default function ClassDetailPage() {
           confirmVariant="danger"
         />
       </div>
+      <StudentDetailModal
+        studentId={selectedStudentId}
+        onClose={() => setSelectedStudentId(null)}
+      />
     </div>
   )
 }

--- a/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.css.ts
+++ b/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.css.ts
@@ -1,0 +1,157 @@
+import { style } from '@vanilla-extract/css'
+import { colors } from '@/styles/tokens/colors'
+import { fontStyles } from '@/styles/tokens/typography'
+
+export const headerStyle = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: '36px',
+})
+
+export const closeButtonStyle = style({
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: colors.gray500,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '4px',
+  selectors: {
+    '&:hover': { color: colors.gray600 },
+  },
+})
+
+export const sectionStyle = style({
+  marginBottom: '36px',
+})
+
+export const sectionTitleStyle = style({
+  marginBottom: '12px',
+})
+
+export const infoRowStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  padding: '14px 16px',
+  backgroundColor: colors.background,
+  borderRadius: '8px',
+  marginBottom: '8px',
+  gap: '16px',
+})
+
+export const infoLabelStyle = style({
+  fontSize: fontStyles.bodyMd.fontSize,
+  fontWeight: fontStyles.bodyMd.fontWeight,
+  color: colors.gray500,
+  width: '140px',
+  flexShrink: 0,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+})
+
+export const infoValueStyle = style({
+  fontSize: fontStyles.bodyMd.fontSize,
+  fontWeight: fontStyles.bodyMd.fontWeight,
+  color: colors.gray900,
+  flex: 1,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+})
+
+export const editButtonStyle = style({
+  fontSize: fontStyles.labelSm.fontSize,
+  fontWeight: fontStyles.labelSm.fontWeight,
+  backgroundColor: colors.primary50,
+  border: 'none',
+  borderRadius: '6px',
+  height: '24px',
+  padding: '0 12px',
+  cursor: 'pointer',
+  color: colors.primary500,
+  flexShrink: 0,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+  selectors: {
+    '&:hover': { backgroundColor: colors.primary100 },
+  },
+})
+
+export const statsGridStyle = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gap: '8px',
+})
+
+export const statCardStyle = style({
+  backgroundColor: colors.gray50,
+  borderRadius: '12px',
+  height: '104px',
+  padding: '16px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+})
+
+export const statLabelStyle = style({
+  fontSize: fontStyles.bodyMd.fontSize,
+  fontWeight: fontStyles.bodyMd.fontWeight,
+  color: colors.gray500,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+})
+
+export const statValueStyle = style({
+  fontSize: fontStyles.headingLg.fontSize,
+  fontWeight: fontStyles.headingLg.fontWeight,
+  color: colors.gray700,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+})
+
+export const trackingListStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+})
+
+export const trackingItemStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '14px 16px',
+  backgroundColor: colors.gray50,
+  borderRadius: '8px',
+})
+
+export const trackingLabelStyle = style({
+  fontSize: fontStyles.bodyMd.fontSize,
+  fontWeight: fontStyles.bodyMd.fontWeight,
+  color: colors.gray900,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+})
+
+export const completeButtonStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  fontSize: fontStyles.labelSm.fontSize,
+  fontWeight: fontStyles.labelSm.fontWeight,
+  color: colors.gray600,
+  backgroundColor: colors.white,
+  border: `1px solid ${colors.gray100}`,
+  borderRadius: '6px',
+  padding: '6px 12px',
+  cursor: 'pointer',
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+  selectors: {
+    '&:hover': {
+      backgroundColor: colors.success50,
+      color: colors.success500,
+      borderColor: colors.success200,
+    },
+  },
+})

--- a/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.tsx
+++ b/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Modal from '@/components/common/Modal'
+import Text from '@/components/common/Text'
+import { studentService } from '@/services/student'
+import { useToastStore } from '@/stores/toastStore'
+import type { StudentDetail } from '@/types/student'
+import CloseIcon from '@/assets/icons/icon-close.svg'
+import CheckIcon from '@/assets/icons/icon-check.svg'
+import {
+  headerStyle,
+  closeButtonStyle,
+  sectionStyle,
+  sectionTitleStyle,
+  infoRowStyle,
+  infoLabelStyle,
+  infoValueStyle,
+  editButtonStyle,
+  statsGridStyle,
+  statCardStyle,
+  statLabelStyle,
+  statValueStyle,
+  trackingListStyle,
+  trackingItemStyle,
+  trackingLabelStyle,
+  completeButtonStyle,
+} from './StudentDetailModal.css'
+
+interface StudentDetailModalProps {
+  studentId: number | null
+  onClose: () => void
+  onUpdated?: () => void
+}
+
+export default function StudentDetailModal({
+  studentId,
+  onClose,
+  onUpdated,
+}: StudentDetailModalProps) {
+  const addToast = useToastStore((s) => s.addToast)
+  const [detail, setDetail] = useState<StudentDetail | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    if (!studentId) return
+    setIsLoading(true)
+    setDetail(null)
+    studentService
+      .getStudent(studentId)
+      .then(setDetail)
+      .catch(() => addToast({ variant: 'error', message: '학생 정보를 불러오지 못했어요.' }))
+      .finally(() => setIsLoading(false))
+  }, [studentId])
+
+  const handleComplete = async (itemId: number) => {
+    try {
+      await studentService.completeItem(itemId)
+      setDetail((prev) =>
+        prev
+          ? {
+              ...prev,
+              incomplete_items: prev.incomplete_items.filter((i: any) => i.id !== itemId),
+              stats: {
+                ...prev.stats,
+                total_incomplete_items: prev.stats.total_incomplete_items - 1,
+                total_complete_items: prev.stats.total_complete_items + 1,
+              },
+            }
+          : prev
+      )
+      addToast({ variant: 'success', message: '완료 처리됐어요.' })
+      onUpdated?.()
+    } catch {
+      addToast({ variant: 'error', message: '완료 처리에 실패했어요.' })
+    }
+  }
+
+  return (
+    <Modal isOpen={!!studentId} onClose={onClose} size="md">
+      {isLoading || !detail ? (
+        <div style={{ padding: '40px', textAlign: 'center' }}>
+          <Text variant="bodyMd" color="gray500">불러오는 중...</Text>
+        </div>
+      ) : (
+        <>
+          {/* 헤더 */}
+          <div className={headerStyle}>
+            <Text variant="headingLg" as="h2">{detail.name}</Text>
+            <button className={closeButtonStyle} onClick={onClose}>
+              <CloseIcon width={24} height={24} />
+            </button>
+          </div>
+
+          {/* 기본 정보 */}
+          <div className={sectionStyle}>
+            <Text variant="headingMd" as="h3" className={sectionTitleStyle}>기본 정보</Text>
+            <div>
+              <div className={infoRowStyle}>
+                <span className={infoLabelStyle}>학생 전화번호</span>
+                <span className={infoValueStyle}>{detail.phone || '-'}</span>
+                <button className={editButtonStyle}>수정</button>
+              </div>
+              <div className={infoRowStyle}>
+                <span className={infoLabelStyle}>학부모 전화번호</span>
+                <span className={infoValueStyle}>{detail.parent_phone || '-'}</span>
+                <button className={editButtonStyle}>수정</button>
+              </div>
+              <div className={infoRowStyle}>
+                <span className={infoLabelStyle}>소속 반</span>
+                <span className={infoValueStyle}>
+                  {detail.classes.map((c) => c.name).join(', ') || '-'}
+                </span>
+                <button className={editButtonStyle}>수정</button>
+              </div>
+            </div>
+          </div>
+
+          {/* 통계 요약 */}
+          <div className={sectionStyle}>
+            <Text variant="headingMd" as="h3" className={sectionTitleStyle}>통계 요약</Text>
+            <div className={statsGridStyle}>
+              <div className={statCardStyle}>
+                <span className={statLabelStyle}>완료율</span>
+                <span className={statValueStyle} style={{ color: '#1DAA7F' }}>
+                  {detail.stats.completion_rate}%
+                </span>
+              </div>
+              <div className={statCardStyle}>
+                <span className={statLabelStyle}>완료</span>
+                <span className={statValueStyle}>{detail.stats.total_complete_items}회</span>
+              </div>
+              <div className={statCardStyle}>
+                <span className={statLabelStyle}>미완료</span>
+                <span className={statValueStyle}>{detail.stats.total_incomplete_items}개</span>
+              </div>
+            </div>
+          </div>
+
+          {/* 추적 항목 */}
+          <div className={sectionStyle}>
+            <Text variant="headingMd" as="h3" className={sectionTitleStyle}>
+              추적 항목{' '}
+              <span style={{ color: '#3B51CC' }}>{detail.incomplete_items.length}</span>
+            </Text>
+            <div className={trackingListStyle}>
+              {detail.incomplete_items.length === 0 ? (
+                <Text variant="bodyMd" color="gray500">미완료 항목이 없어요.</Text>
+              ) : (
+                detail.incomplete_items.map((item: any) => (
+                  <div key={item.id} className={trackingItemStyle}>
+                    <span className={trackingLabelStyle}>{item.label ?? item.name}</span>
+                    <button
+                      className={completeButtonStyle}
+                      onClick={() => handleComplete(item.id)}
+                    >
+                      <CheckIcon width={16} height={16} />
+                      완료 처리
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </Modal>
+  )
+}

--- a/src/app/(main)/management/_components/StudentTable/StudentTable.tsx
+++ b/src/app/(main)/management/_components/StudentTable/StudentTable.tsx
@@ -25,6 +25,7 @@ interface StudentTableProps {
   students: Student[]
   middleColumns: MiddleColumn[]
   onDelete: (id: number) => void
+  onRowClick?: (id: number) => void
 }
 
 // 고정 컬럼 수: 학생, 학생 전화, 학부모 전화, 학교, 완료율
@@ -42,7 +43,7 @@ function getProgressColor(rate: number): string {
   return colors.error500
 }
 
-export default function StudentTable({ students, middleColumns, onDelete }: StudentTableProps) {
+export default function StudentTable({ students, middleColumns, onDelete, onRowClick }: StudentTableProps) {
   const totalColumns = FIXED_COLUMN_COUNT + middleColumns.length
   const cellPaddingRight = getCellPaddingRight(totalColumns)
 
@@ -79,7 +80,11 @@ export default function StudentTable({ students, middleColumns, onDelete }: Stud
         {students.map((student) => {
           const color = getProgressColor(student.completion_rate)
           return (
-            <tr key={student.id}>
+            <tr
+              key={student.id}
+              onClick={() => onRowClick?.(student.id)}
+              style={{ cursor: onRowClick ? 'pointer' : 'default' }}
+            >
               <td className={tdStyle}>{student.name}</td>
               <td className={tdStyle}>{student.phone}</td>
               <td className={tdStyle}>{student.parent_phone}</td>

--- a/src/app/(main)/management/page.tsx
+++ b/src/app/(main)/management/page.tsx
@@ -27,6 +27,7 @@ import ConfirmModal from '@/components/common/ConfirmModal'
 import { studentService } from '@/services/student'
 import type { Student } from '@/types/student'
 import { useToastStore } from '@/stores/toastStore'
+import StudentDetailModal from './_components/StudentDetailModal/StudentDetailModal'
 
 const FILTER_OPTIONS = [
   { label: '전체', value: 'all' },
@@ -43,6 +44,7 @@ function ManagementContent() {
   const [students, setStudents] = useState<Student[]>([])
   const [isLoadingStudents, setIsLoadingStudents] = useState(false)
   const addToast = useToastStore((s) => s.addToast)
+  const [selectedStudentId, setSelectedStudentId] = useState<number | null>(null)
 
   useEffect(() => {
     if (tab !== 'students') return
@@ -180,6 +182,7 @@ function ManagementContent() {
               },
             ]}
             onDelete={(id) => setDeleteStudentTarget(id)}
+            onRowClick={(id) => setSelectedStudentId(id)}
           />
 
           <ConfirmModal
@@ -190,6 +193,12 @@ function ManagementContent() {
             descriptions={['삭제 후에는 복구할 수 없어요.']}
             confirmLabel="삭제"
             confirmVariant="danger"
+          />
+
+          <StudentDetailModal
+            studentId={selectedStudentId}
+            onClose={() => setSelectedStudentId(null)}
+            onUpdated={() => studentService.getStudents().then((res) => setStudents(res.data))}
           />
         </>
       )}

--- a/src/services/student.ts
+++ b/src/services/student.ts
@@ -52,4 +52,10 @@ export const studentService = {
   async deleteStudent(id: number): Promise<void> {
     await axiosInstance.delete(`/students/${id}`)
   },
+
+  async completeItem(itemId: number): Promise<void> {
+    await axiosInstance.patch(`/lesson-student-data/${itemId}/complete`, {
+      is_completed: true,
+    })
+  },
 }


### PR DESCRIPTION
## 이슈 넘버

- close #41 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] `StudentDetailModal` 컴포넌트 신규 생성
- [x] `GET /api/v1/students/{id}` 연동
- [x] `StudentTable`에 `onRowClick` props 추가
- [x] 전체 학생 탭 / 반 상세 페이지에 모달 연동