### PR TITLE
feat: 반 관리 API 연동

### DIFF
--- a/src/app/(main)/management/[id]/_components/AddStudentModal/AddStudentModal.tsx
+++ b/src/app/(main)/management/[id]/_components/AddStudentModal/AddStudentModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Text from '@/components/common/Text'
 import Input from '@/components/common/Input'
 import Button from '@/components/common/Button'
@@ -8,7 +8,8 @@ import Modal from '@/components/common/Modal'
 import CheckIcon from '@/assets/icons/icon-check.svg'
 import { colors } from '@/styles/tokens/colors'
 import useToggleArray from '@/hooks/useToggleArray'
-import { MOCK_CANDIDATE_STUDENTS } from '@/mocks/management'
+import { studentService } from '@/services/student'
+import type { Student } from '@/types/student'
 import {
   titleStyle,
   searchWrapperStyle,
@@ -29,10 +30,16 @@ interface AddStudentModalProps {
 
 export default function AddStudentModal({ isOpen, onClose, onConfirm }: AddStudentModalProps) {
   const [search, setSearch] = useState('')
+  const [candidates, setCandidates] = useState<Student[]>([])
   const { items: selectedIds, toggle: toggleSelect, reset: resetIds } = useToggleArray<number>()
 
-  const filtered = MOCK_CANDIDATE_STUDENTS.filter((s) =>
-    s.name.includes(search) || s.phone.includes(search)
+  useEffect(() => {
+    if (!isOpen) return
+    studentService.getStudents().then((res) => setCandidates(res.data))
+  }, [isOpen])
+
+  const filtered = candidates.filter(
+    (s) => s.name.includes(search) || s.phone.includes(search)
   )
 
   const handleClose = () => {

--- a/src/app/(main)/management/[id]/page.tsx
+++ b/src/app/(main)/management/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
+import { use, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
 import { colors } from '@/styles/tokens/colors'
 import useDisclosure from '@/hooks/useDisclosure'
 import Text from '@/components/common/Text'
@@ -17,17 +17,80 @@ import AddStudentModal from './_components/AddStudentModal/AddStudentModal'
 import ConfirmModal from '@/components/common/ConfirmModal'
 import ClassFormModal from '../_components/ClassFormModal/ClassFormModal'
 import StudentDetailModal from '../_components/StudentDetailModal/StudentDetailModal'
+import { classService, type ClassDetail } from '@/services/class'
+import { useToastStore } from '@/stores/toastStore'
+import type { Student } from '@/types/student'
 
-import { MOCK_CLASS, MOCK_CLASS_STUDENTS } from '@/mocks/management'
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토']
+const formatSchedule = (schedules: { day_of_week: number }[]) =>
+  schedules.map((s) => DAY_NAMES[s.day_of_week]).join('·')
 
-export default function ClassDetailPage() {
+export default function ClassDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  const classId = Number(id)
   const router = useRouter()
+  const addToast = useToastStore((s) => s.addToast)
   const addStudent = useDisclosure()
-  const [deleteStudentTarget, setDeleteStudentTarget] = useState<number | null>(null)
   const endClass = useDisclosure()
   const deleteClass = useDisclosure()
   const editClass = useDisclosure()
+
+  const [classDetail, setClassDetail] = useState<ClassDetail | null>(null)
+  const [students, setStudents] = useState<Student[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [deleteStudentTarget, setDeleteStudentTarget] = useState<number | null>(null)
   const [selectedStudentId, setSelectedStudentId] = useState<number | null>(null)
+
+  useEffect(() => {
+    classService
+      .getClass(classId)
+      .then((data) => {
+        setClassDetail(data)
+        setStudents(data.students)
+      })
+      .catch(() => {
+        addToast({ variant: 'error', message: '반 정보를 불러오지 못했어요.' })
+        router.push('/management')
+      })
+      .finally(() => setIsLoading(false))
+  }, [classId])
+
+  const handleDeleteStudent = async () => {
+    if (!deleteStudentTarget) return
+    try {
+      await classService.removeStudent(classId, deleteStudentTarget)
+      setStudents((prev) => prev.filter((s) => s.id !== deleteStudentTarget))
+      addToast({ variant: 'success', message: '학생이 제거됐어요.' })
+    } catch {
+      addToast({ variant: 'error', message: '학생 제거에 실패했어요.' })
+    } finally {
+      setDeleteStudentTarget(null)
+    }
+  }
+
+  const handleEndClass = async () => {
+    try {
+      await classService.endClass(classId)
+      addToast({ variant: 'success', message: '반이 종료됐어요.' })
+      endClass.close()
+      router.push('/management')
+    } catch {
+      addToast({ variant: 'error', message: '반 종료에 실패했어요.' })
+    }
+  }
+
+  const handleDeleteClass = async () => {
+    try {
+      await classService.deleteClass(classId)
+      addToast({ variant: 'success', message: '반이 삭제됐어요.' })
+      deleteClass.close()
+      router.push('/management')
+    } catch {
+      addToast({ variant: 'error', message: '반 삭제에 실패했어요.' })
+    }
+  }
+
+  if (isLoading || !classDetail) return null
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '60px' }}>
@@ -39,9 +102,7 @@ export default function ClassDetailPage() {
         >
           <ArrowLeftIcon width={24} height={24} />
         </button>
-        <Text variant="display" as="h1">
-          {MOCK_CLASS.name}
-        </Text>
+        <Text variant="display" as="h1">{classDetail.name}</Text>
       </div>
 
       {/* 반 정보 */}
@@ -57,32 +118,42 @@ export default function ClassDetailPage() {
           >
             수정
           </Button>
-
           <ClassFormModal
             isOpen={editClass.isOpen}
             onClose={editClass.close}
-            onConfirm={(data) => console.log('반 수정', data)}
+            onConfirm={async (data) => {
+              try {
+                const updated = await classService.updateClass(classId, {
+                  academy_name: data.academyName,
+                  name: data.name,
+                  day_of_week: data.dayOfWeek,
+                })
+                setClassDetail((prev) => prev ? { ...prev, ...updated } : prev)
+                editClass.close()
+                addToast({ variant: 'success', message: '반 정보가 수정됐어요.' })
+              } catch {
+                addToast({ variant: 'error', message: '반 정보 수정에 실패했어요.' })
+              }
+            }}
             mode="edit"
             defaultValues={{
-              academyName: MOCK_CLASS.academyName,
-              name: MOCK_CLASS.name,
-              dayOfWeek: [2, 5],
+              academyName: classDetail.academy_name,
+              name: classDetail.name,
+              dayOfWeek: classDetail.schedules.map((s) => s.day_of_week),
             }}
           />
         </div>
-        <ClassInfoTable {...MOCK_CLASS} />
+        <ClassInfoTable
+          academyName={classDetail.academy_name}
+          schedule={formatSchedule(classDetail.schedules)}
+          time="-"
+          template="-"
+        />
       </section>
 
       {/* 학생 명단 */}
       <section>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: '24px',
-          }}
-        >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
           <Text variant="headingMd">학생 명단</Text>
           <Button
             variant="primary"
@@ -92,15 +163,24 @@ export default function ClassDetailPage() {
           >
             학생 등록
           </Button>
-
           <AddStudentModal
             isOpen={addStudent.isOpen}
             onClose={addStudent.close}
-            onConfirm={(ids) => console.log('추가할 학생 ids:', ids)}
+            onConfirm={async (ids) => {
+              try {
+                await classService.addStudents(classId, ids)
+                const updated = await classService.getClass(classId)
+                setStudents(updated.students)
+                addStudent.close()
+                addToast({ variant: 'success', message: '학생이 추가됐어요.' })
+              } catch {
+                addToast({ variant: 'error', message: '학생 추가에 실패했어요.' })
+              }
+            }}
           />
         </div>
         <StudentTable
-          students={MOCK_CLASS_STUDENTS}
+          students={students}
           middleColumns={[
             {
               header: '메모',
@@ -128,15 +208,11 @@ export default function ClassDetailPage() {
           onConfirm={deleteClass.open}
         />
 
-        {/* 모달들 */}
         <ConfirmModal
           isOpen={!!deleteStudentTarget}
           onClose={() => setDeleteStudentTarget(null)}
-          onConfirm={() => {
-            console.log('학생 삭제', deleteStudentTarget)
-            setDeleteStudentTarget(null)
-          }}
-          title={`'${MOCK_CLASS_STUDENTS.find((s) => s.id === deleteStudentTarget)?.name}' 학생을 ${MOCK_CLASS.name}에서 제거할까요?`}
+          onConfirm={handleDeleteStudent}
+          title={`'${students.find((s) => s.id === deleteStudentTarget)?.name}' 학생을 ${classDetail.name}에서 제거할까요?`}
           descriptions={['반에서 제거되지만 학생 정보는 그대로 남아요.']}
           confirmLabel="제거"
           confirmVariant="danger"
@@ -145,11 +221,8 @@ export default function ClassDetailPage() {
         <ConfirmModal
           isOpen={endClass.isOpen}
           onClose={endClass.close}
-          onConfirm={() => {
-            console.log('반 종료')
-            endClass.close()
-          }}
-          title={`'${MOCK_CLASS.name}'을 종료할까요?`}
+          onConfirm={handleEndClass}
+          title={`'${classDetail.name}'을 종료할까요?`}
           descriptions={['종료 후에는 수업 입력이 불가능해요.']}
           confirmLabel="종료"
           confirmVariant="primary"
@@ -158,16 +231,14 @@ export default function ClassDetailPage() {
         <ConfirmModal
           isOpen={deleteClass.isOpen}
           onClose={deleteClass.close}
-          onConfirm={() => {
-            console.log('반 삭제')
-            deleteClass.close()
-          }}
-          title={`'${MOCK_CLASS.name}'을 삭제할까요?`}
+          onConfirm={handleDeleteClass}
+          title={`'${classDetail.name}'을 삭제할까요?`}
           descriptions={['학생 배정이 해제되지만, 수업 기록은 그대로 남아요.']}
           confirmLabel="삭제"
           confirmVariant="danger"
         />
       </div>
+
       <StudentDetailModal
         studentId={selectedStudentId}
         onClose={() => setSelectedStudentId(null)}

--- a/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.tsx
+++ b/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.tsx
@@ -5,7 +5,7 @@ import Modal from '@/components/common/Modal'
 import Text from '@/components/common/Text'
 import { studentService } from '@/services/student'
 import { useToastStore } from '@/stores/toastStore'
-import type { StudentDetail } from '@/types/student'
+import type { StudentDetail, IncompleteItem } from '@/types/student'
 import CloseIcon from '@/assets/icons/icon-close.svg'
 import CheckIcon from '@/assets/icons/icon-check.svg'
 import {
@@ -60,7 +60,9 @@ export default function StudentDetailModal({
         prev
           ? {
               ...prev,
-              incomplete_items: prev.incomplete_items.filter((i: any) => i.id !== itemId),
+              incomplete_items: prev.incomplete_items.filter(
+                (i) => i.lesson_student_data_id !== itemId
+              ),
               stats: {
                 ...prev.stats,
                 total_incomplete_items: prev.stats.total_incomplete_items - 1,
@@ -80,13 +82,17 @@ export default function StudentDetailModal({
     <Modal isOpen={!!studentId} onClose={onClose} size="md">
       {isLoading || !detail ? (
         <div style={{ padding: '40px', textAlign: 'center' }}>
-          <Text variant="bodyMd" color="gray500">불러오는 중...</Text>
+          <Text variant="bodyMd" color="gray500">
+            불러오는 중...
+          </Text>
         </div>
       ) : (
         <>
           {/* 헤더 */}
           <div className={headerStyle}>
-            <Text variant="headingLg" as="h2">{detail.name}</Text>
+            <Text variant="headingLg" as="h2">
+              {detail.name}
+            </Text>
             <button className={closeButtonStyle} onClick={onClose}>
               <CloseIcon width={24} height={24} />
             </button>
@@ -94,7 +100,9 @@ export default function StudentDetailModal({
 
           {/* 기본 정보 */}
           <div className={sectionStyle}>
-            <Text variant="headingMd" as="h3" className={sectionTitleStyle}>기본 정보</Text>
+            <Text variant="headingMd" as="h3" className={sectionTitleStyle}>
+              기본 정보
+            </Text>
             <div>
               <div className={infoRowStyle}>
                 <span className={infoLabelStyle}>학생 전화번호</span>
@@ -118,7 +126,9 @@ export default function StudentDetailModal({
 
           {/* 통계 요약 */}
           <div className={sectionStyle}>
-            <Text variant="headingMd" as="h3" className={sectionTitleStyle}>통계 요약</Text>
+            <Text variant="headingMd" as="h3" className={sectionTitleStyle}>
+              통계 요약
+            </Text>
             <div className={statsGridStyle}>
               <div className={statCardStyle}>
                 <span className={statLabelStyle}>완료율</span>
@@ -140,19 +150,25 @@ export default function StudentDetailModal({
           {/* 추적 항목 */}
           <div className={sectionStyle}>
             <Text variant="headingMd" as="h3" className={sectionTitleStyle}>
-              추적 항목{' '}
-              <span style={{ color: '#3B51CC' }}>{detail.incomplete_items.length}</span>
+              추적 항목 <span style={{ color: '#3B51CC' }}>{detail.incomplete_items.length}</span>
             </Text>
             <div className={trackingListStyle}>
               {detail.incomplete_items.length === 0 ? (
-                <Text variant="bodyMd" color="gray500">미완료 항목이 없어요.</Text>
+                <Text variant="bodyMd" color="gray500">
+                  미완료 항목이 없어요.
+                </Text>
               ) : (
-                detail.incomplete_items.map((item: any) => (
-                  <div key={item.id} className={trackingItemStyle}>
-                    <span className={trackingLabelStyle}>{item.label ?? item.name}</span>
+                detail.incomplete_items.map((item: IncompleteItem) => (
+                  <div key={item.lesson_student_data_id} className={trackingItemStyle}>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                      <span className={trackingLabelStyle}>{item.item_name}</span>
+                      <span style={{ fontSize: '12px', color: '#9492A9' }}>
+                        {item.lesson_date} · {item.class_name}
+                      </span>
+                    </div>
                     <button
                       className={completeButtonStyle}
-                      onClick={() => handleComplete(item.id)}
+                      onClick={() => handleComplete(item.lesson_student_data_id)}
                     >
                       <CheckIcon width={16} height={16} />
                       완료 처리

--- a/src/app/(main)/management/page.tsx
+++ b/src/app/(main)/management/page.tsx
@@ -4,7 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { Suspense, useState, useEffect } from 'react'
 import Text from '@/components/common/Text'
 import useDisclosure from '@/hooks/useDisclosure'
-import { MOCK_CLASSES } from '@/mocks/management'
+import { classService, type Class } from '@/services/class'
 import Button from '@/components/common/Button'
 import PlusIcon from '@/assets/icons/icon-plus.svg'
 import UploadIcon from '@/assets/icons/icon-upload.svg'
@@ -35,6 +35,8 @@ const FILTER_OPTIONS = [
   { label: '종료', value: 'ended' },
 ]
 
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토']
+
 function ManagementContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -46,6 +48,9 @@ function ManagementContent() {
   const addToast = useToastStore((s) => s.addToast)
   const [selectedStudentId, setSelectedStudentId] = useState<number | null>(null)
 
+  const formatSchedule = (schedules: { day_of_week: number }[]) =>
+    schedules.map((s) => DAY_NAMES[s.day_of_week]).join('·')
+
   useEffect(() => {
     if (tab !== 'students') return
     setIsLoadingStudents(true)
@@ -56,11 +61,18 @@ function ManagementContent() {
       .finally(() => setIsLoadingStudents(false))
   }, [tab])
 
-  const filteredClasses = MOCK_CLASSES.filter((cls) => {
-    if (filter === 'active') return !cls.isEnded
-    if (filter === 'ended') return cls.isEnded
-    return true
-  })
+  const [classes, setClasses] = useState<Class[]>([])
+  const [isLoadingClasses, setIsLoadingClasses] = useState(false)
+
+  useEffect(() => {
+    if (tab !== 'class') return
+    setIsLoadingClasses(true)
+    classService
+      .getClasses(filter === 'all' ? undefined : { status: filter as 'active' | 'ended' })
+      .then((res) => setClasses(res.data))
+      .catch((err) => console.error('반 목록 조회 실패', err))
+      .finally(() => setIsLoadingClasses(false))
+  }, [tab, filter])
 
   const addClass = useDisclosure()
   const addStudent = useDisclosure()
@@ -131,8 +143,16 @@ function ManagementContent() {
             />
           </div>
           <div className={gridStyle}>
-            {filteredClasses.map((cls) => (
-              <ClassCard key={cls.id} {...cls} />
+            {classes.map((cls) => (
+              <ClassCard
+                key={cls.id}
+                id={cls.id}
+                name={cls.name}
+                academyName={cls.academy_name}
+                schedule={formatSchedule(cls.schedules)}
+                studentCount={cls.student_count}
+                isEnded={!!cls.ended_at}
+              />
             ))}
             <AddCard
               icon={<PlusCircleIcon width={36} height={36} />}
@@ -143,8 +163,23 @@ function ManagementContent() {
             <ClassFormModal
               isOpen={addClass.isOpen}
               onClose={addClass.close}
-              onConfirm={(data) => {
-                console.log('새 반 추가:', data)
+              onConfirm={async (data) => {
+                try {
+                  await classService.createClass({
+                    academy_name: data.academyName,
+                    name: data.name,
+                    day_of_week: data.dayOfWeek,
+                  })
+                  const res = await classService.getClasses(
+                    filter === 'all' ? undefined : { status: filter as 'active' | 'ended' }
+                  )
+                  setClasses(res.data)
+                  addClass.close()
+                  addToast({ variant: 'success', message: '반이 생성됐어요.' })
+                } catch (err) {
+                  console.error('반 생성 실패', err)
+                  addToast({ variant: 'error', message: '반 생성에 실패했어요.' })
+                }
               }}
               mode="add"
             />

--- a/src/app/(main)/template/page.tsx
+++ b/src/app/(main)/template/page.tsx
@@ -69,7 +69,7 @@ export default function TemplatePage() {
             id={template.id}
             title={template.name}
             classCount={template.class_count}
-            classList={template.class_list}
+            classList={template.class_list.map((c) => c.name)}
             onDelete={(id) =>
               setDeleteTarget({ id, title: template.name, classCount: template.class_count })
             }

--- a/src/services/class.ts
+++ b/src/services/class.ts
@@ -1,4 +1,5 @@
 import axiosInstance from '@/lib/api/axiosInstance'
+import type { Student } from '@/types/student'
 
 export interface ClassSchedule {
   day_of_week: number
@@ -13,14 +14,75 @@ export interface Class {
   ended_at: string | null
 }
 
+export interface ClassDetail extends Class {
+  students: Student[]
+}
+
 export interface ClassListResponse {
   data: Class[]
   meta: { total: number }
 }
 
+export interface CreateClassDto {
+  academy_name: string
+  name: string
+  day_of_week: number[]
+}
+
+export interface UpdateClassDto {
+  academy_name?: string
+  name?: string
+  day_of_week?: number[]
+}
+
 export const classService = {
+  // 목록 조회
   async getClasses(params?: { status?: 'active' | 'ended' }): Promise<ClassListResponse> {
     const { data } = await axiosInstance.get('/classes', { params })
     return data.data
+  },
+
+  // 상세 조회
+  async getClass(id: number): Promise<ClassDetail> {
+    const { data } = await axiosInstance.get(`/classes/${id}`)
+    return data.data
+  },
+
+  // 생성
+  async createClass(dto: CreateClassDto): Promise<Class> {
+    const { data } = await axiosInstance.post('/classes', dto)
+    return data.data
+  },
+
+  // 수정
+  async updateClass(id: number, dto: UpdateClassDto): Promise<Class> {
+    const { data } = await axiosInstance.put(`/classes/${id}`, dto)
+    return data.data
+  },
+
+  // 삭제
+  async deleteClass(id: number): Promise<void> {
+    await axiosInstance.delete(`/classes/${id}`)
+  },
+
+  // 종료
+  async endClass(id: number, ended_at?: string): Promise<void> {
+    await axiosInstance.post(`/classes/${id}/end`, { ended_at })
+  },
+
+  // 소속 학생 목록 조회
+  async getClassStudents(id: number): Promise<Student[]> {
+    const { data } = await axiosInstance.get(`/classes/${id}/students`)
+    return data.data
+  },
+
+  // 학생 추가
+  async addStudents(id: number, student_ids: number[]): Promise<void> {
+    await axiosInstance.post(`/classes/${id}/students`, { student_ids })
+  },
+
+  // 학생 제거
+  async removeStudent(classId: number, studentId: number): Promise<void> {
+    await axiosInstance.delete(`/classes/${classId}/students/${studentId}`)
   },
 }

--- a/src/services/template.ts
+++ b/src/services/template.ts
@@ -11,12 +11,17 @@ export interface TemplateItemDetail {
   sort_order: number
 }
 
+export interface TemplateClass {
+  id: number
+  name: string
+}
+
 export interface Template {
   id: number
   name: string
   item_count: number
   class_count: number
-  class_list: string[]
+  class_list: TemplateClass[]
   created_at: string
 }
 

--- a/src/types/student.ts
+++ b/src/types/student.ts
@@ -22,6 +22,14 @@ export interface Student {
   remaining_task_count: number
 }
 
+export interface IncompleteItem {
+  lesson_student_data_id: number
+  item_name: string
+  lesson_date: string
+  class_name: string
+  template_name: string
+}
+
 export interface StudentDetail {
   id: number
   name: string
@@ -30,5 +38,5 @@ export interface StudentDetail {
   school_name: string
   classes: StudentClass[]
   stats: StudentStats
-  incomplete_items: any[]
+  incomplete_items: IncompleteItem[]
 }


### PR DESCRIPTION
## 이슈 넘버

- close #43 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
### services/class.ts 확장
- 반 생성/상세/수정/삭제/종료 API 연동
- 반 소속 학생 목록 조회/추가/제거 API 연동

### management/page.tsx
- `MOCK_CLASSES` 제거, 반 목록 API 연동
- 반 생성 API 연동 및 토스트 추가
- 필터(전체/진행중/종료) 연동

### management/[id]/page.tsx
- `MOCK_CLASS`, `MOCK_CLASS_STUDENTS` 제거
- 반 상세 조회/수정/종료/삭제 API 연동
- 학생 추가/제거 API 연동
- 토스트 알림 추가

### AddStudentModal
- `MOCK_CANDIDATE_STUDENTS` 제거, `GET /api/v1/students` 로 동적 로드

### types/student.ts
- `IncompleteItem` 타입 추가
- `StudentDetail.incomplete_items` `any[]` → `IncompleteItem[]` 수정

### StudentDetailModal
- `any` 제거, `IncompleteItem` 타입 적용
- 추적 항목 날짜/반 이름 표시 추가

### 기타
- `services/template.ts` `class_list` 타입 `string[]` → `{ id, name }[]` 수정
- `template/page.tsx` `classList` 변환 로직 추가
