### PR TITLE
feat: 학생 정보 수정 API 연동

### DIFF
--- a/src/app/(main)/management/_components/AddStudentFormModal/AddStudentFormModal.tsx
+++ b/src/app/(main)/management/_components/AddStudentFormModal/AddStudentFormModal.tsx
@@ -16,34 +16,56 @@ import {
   actionsStyle,
 } from './AddStudentFormModal.css'
 
+interface StudentFormData {
+  name: string
+  phone: string
+  parent_phone: string
+  school_name: string
+  class_ids: number[]
+}
+
 interface AddStudentFormModalProps {
   isOpen: boolean
   onClose: () => void
-  onConfirm: (data: {
-    name: string
-    phone: string
-    parent_phone: string
-    school_name: string
-    class_ids: number[]
-  }) => void
+  onConfirm: (data: StudentFormData) => void
+  mode?: 'add' | 'edit'
+  defaultValues?: Partial<StudentFormData>
 }
 
 export default function AddStudentFormModal({
   isOpen,
   onClose,
   onConfirm,
+  mode = 'add',
+  defaultValues,
 }: AddStudentFormModalProps) {
   const [name, setName] = useState('')
   const [phone, setPhone] = useState('')
   const [parentPhone, setParentPhone] = useState('')
   const [schoolName, setSchoolName] = useState('')
   const [classes, setClasses] = useState<Class[]>([])
-  const { items: selectedClassIds, toggle: toggleClass, reset: resetClasses } = useToggleArray<number>()
+  const {
+    items: selectedClassIds,
+    toggle: toggleClass,
+    reset: resetClasses,
+    set: setSelectedClassIds,
+  } = useToggleArray<number>()
 
   useEffect(() => {
     if (!isOpen) return
-    classService.getClasses({ status: 'active' })
-      .then((res) => setClasses(res.data))
+    classService
+      .getClasses()
+      .then((res) => {
+        setClasses(res.data)
+        // classes 로드 후 defaultValues 적용
+        if (defaultValues) {
+          setName(defaultValues.name ?? '')
+          setPhone(defaultValues.phone ?? '')
+          setParentPhone(defaultValues.parent_phone ?? '')
+          setSchoolName(defaultValues.school_name ?? '')
+          setSelectedClassIds(defaultValues.class_ids ?? [])
+        }
+      })
       .catch((err) => console.error('반 목록 조회 실패', err))
   }, [isOpen])
 
@@ -71,7 +93,9 @@ export default function AddStudentFormModal({
   return (
     <Modal isOpen={isOpen} onClose={handleClose} size="md">
       <div style={{ marginBottom: '24px' }}>
-        <Text variant="headingLg" as="h2">학생 등록</Text>
+        <Text variant="headingLg" as="h2">
+          {mode === 'add' ? '학생 등록' : '학생 정보 수정'}
+        </Text>
       </div>
       <div className={fieldGroupStyle}>
         <div className={fieldStyle}>
@@ -86,11 +110,19 @@ export default function AddStudentFormModal({
         </div>
         <div className={fieldStyle}>
           <span className={labelStyle}>학부모 전화번호</span>
-          <Input variant="gray" value={parentPhone} onChange={(e) => setParentPhone(e.target.value)} />
+          <Input
+            variant="gray"
+            value={parentPhone}
+            onChange={(e) => setParentPhone(e.target.value)}
+          />
         </div>
         <div className={fieldStyle}>
           <span className={labelStyle}>학교명</span>
-          <Input variant="gray" value={schoolName} onChange={(e) => setSchoolName(e.target.value)} />
+          <Input
+            variant="gray"
+            value={schoolName}
+            onChange={(e) => setSchoolName(e.target.value)}
+          />
         </div>
         <div className={fieldStyle}>
           <span className={labelStyle}>소속 반</span>
@@ -108,7 +140,9 @@ export default function AddStudentFormModal({
         </div>
       </div>
       <div className={actionsStyle}>
-        <Button variant="ghost" size="lg" fullWidth onClick={handleClose}>취소</Button>
+        <Button variant="ghost" size="lg" fullWidth onClick={handleClose}>
+          취소
+        </Button>
         <Button
           variant="primary"
           size="lg"
@@ -116,7 +150,7 @@ export default function AddStudentFormModal({
           disabled={!name.trim()}
           onClick={handleConfirm}
         >
-          등록하기
+          {mode === 'add' ? '등록하기' : '저장'}
         </Button>
       </div>
     </Modal>

--- a/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.css.ts
+++ b/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.css.ts
@@ -31,16 +31,6 @@ export const sectionTitleStyle = style({
   marginBottom: '12px',
 })
 
-export const infoRowStyle = style({
-  display: 'flex',
-  alignItems: 'center',
-  padding: '14px 16px',
-  backgroundColor: colors.background,
-  borderRadius: '8px',
-  marginBottom: '8px',
-  gap: '16px',
-})
-
 export const infoLabelStyle = style({
   fontSize: fontStyles.bodyMd.fontSize,
   fontWeight: fontStyles.bodyMd.fontWeight,

--- a/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.tsx
+++ b/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.tsx
@@ -3,17 +3,19 @@
 import { useEffect, useState } from 'react'
 import Modal from '@/components/common/Modal'
 import Text from '@/components/common/Text'
+import { colors } from '@/styles/tokens/colors'
 import { studentService } from '@/services/student'
 import { useToastStore } from '@/stores/toastStore'
+import useDisclosure from '@/hooks/useDisclosure'
 import type { StudentDetail, IncompleteItem } from '@/types/student'
 import CloseIcon from '@/assets/icons/icon-close.svg'
 import CheckIcon from '@/assets/icons/icon-check.svg'
+import AddStudentFormModal from '../AddStudentFormModal/AddStudentFormModal'
 import {
   headerStyle,
   closeButtonStyle,
   sectionStyle,
   sectionTitleStyle,
-  infoRowStyle,
   infoLabelStyle,
   infoValueStyle,
   editButtonStyle,
@@ -41,6 +43,7 @@ export default function StudentDetailModal({
   const addToast = useToastStore((s) => s.addToast)
   const [detail, setDetail] = useState<StudentDetail | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const editStudent = useDisclosure()
 
   useEffect(() => {
     if (!studentId) return
@@ -79,107 +82,154 @@ export default function StudentDetailModal({
   }
 
   return (
-    <Modal isOpen={!!studentId} onClose={onClose} size="md">
-      {isLoading || !detail ? (
-        <div style={{ padding: '40px', textAlign: 'center' }}>
-          <Text variant="bodyMd" color="gray500">
-            불러오는 중...
-          </Text>
-        </div>
-      ) : (
-        <>
-          {/* 헤더 */}
-          <div className={headerStyle}>
-            <Text variant="headingLg" as="h2">
-              {detail.name}
+    <>
+      <Modal isOpen={!!studentId} onClose={onClose} size="md">
+        {isLoading || !detail ? (
+          <div style={{ padding: '40px', textAlign: 'center' }}>
+            <Text variant="bodyMd" color="gray500">
+              불러오는 중...
             </Text>
-            <button className={closeButtonStyle} onClick={onClose}>
-              <CloseIcon width={24} height={24} />
-            </button>
           </div>
-
-          {/* 기본 정보 */}
-          <div className={sectionStyle}>
-            <Text variant="headingMd" as="h3" className={sectionTitleStyle}>
-              기본 정보
-            </Text>
-            <div>
-              <div className={infoRowStyle}>
-                <span className={infoLabelStyle}>학생 전화번호</span>
-                <span className={infoValueStyle}>{detail.phone || '-'}</span>
-                <button className={editButtonStyle}>수정</button>
-              </div>
-              <div className={infoRowStyle}>
-                <span className={infoLabelStyle}>학부모 전화번호</span>
-                <span className={infoValueStyle}>{detail.parent_phone || '-'}</span>
-                <button className={editButtonStyle}>수정</button>
-              </div>
-              <div className={infoRowStyle}>
-                <span className={infoLabelStyle}>소속 반</span>
-                <span className={infoValueStyle}>
-                  {detail.classes.map((c) => c.name).join(', ') || '-'}
-                </span>
-                <button className={editButtonStyle}>수정</button>
-              </div>
+        ) : (
+          <>
+            {/* 헤더 */}
+            <div className={headerStyle}>
+              <Text variant="headingLg" as="h2">
+                {detail.name}
+              </Text>
+              <button className={closeButtonStyle} onClick={onClose}>
+                <CloseIcon width={24} height={24} />
+              </button>
             </div>
-          </div>
 
-          {/* 통계 요약 */}
-          <div className={sectionStyle}>
-            <Text variant="headingMd" as="h3" className={sectionTitleStyle}>
-              통계 요약
-            </Text>
-            <div className={statsGridStyle}>
-              <div className={statCardStyle}>
-                <span className={statLabelStyle}>완료율</span>
-                <span className={statValueStyle} style={{ color: '#1DAA7F' }}>
-                  {detail.stats.completion_rate}%
-                </span>
-              </div>
-              <div className={statCardStyle}>
-                <span className={statLabelStyle}>완료</span>
-                <span className={statValueStyle}>{detail.stats.total_complete_items}회</span>
-              </div>
-              <div className={statCardStyle}>
-                <span className={statLabelStyle}>미완료</span>
-                <span className={statValueStyle}>{detail.stats.total_incomplete_items}개</span>
-              </div>
-            </div>
-          </div>
-
-          {/* 추적 항목 */}
-          <div className={sectionStyle}>
-            <Text variant="headingMd" as="h3" className={sectionTitleStyle}>
-              추적 항목 <span style={{ color: '#3B51CC' }}>{detail.incomplete_items.length}</span>
-            </Text>
-            <div className={trackingListStyle}>
-              {detail.incomplete_items.length === 0 ? (
-                <Text variant="bodyMd" color="gray500">
-                  미완료 항목이 없어요.
+            {/* 기본 정보 */}
+            <div className={sectionStyle}>
+              <div
+                style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '12px' }}
+              >
+                <Text variant="headingMd" as="h3">
+                  기본 정보
                 </Text>
-              ) : (
-                detail.incomplete_items.map((item: IncompleteItem) => (
-                  <div key={item.lesson_student_data_id} className={trackingItemStyle}>
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                      <span className={trackingLabelStyle}>{item.item_name}</span>
-                      <span style={{ fontSize: '12px', color: '#9492A9' }}>
-                        {item.lesson_date} · {item.class_name}
-                      </span>
-                    </div>
-                    <button
-                      className={completeButtonStyle}
-                      onClick={() => handleComplete(item.lesson_student_data_id)}
-                    >
-                      <CheckIcon width={16} height={16} />
-                      완료 처리
-                    </button>
-                  </div>
-                ))
-              )}
+                <button className={editButtonStyle} onClick={editStudent.open}>
+                  수정
+                </button>
+              </div>
+              <div
+                style={{
+                  backgroundColor: colors.gray50,
+                  borderRadius: '12px',
+                  padding: '16px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '12px',
+                }}
+              >
+                <div style={{ display: 'flex', gap: '16px' }}>
+                  <span className={infoLabelStyle}>학생 전화번호</span>
+                  <span className={infoValueStyle}>{detail.phone || '-'}</span>
+                </div>
+                <div style={{ display: 'flex', gap: '16px' }}>
+                  <span className={infoLabelStyle}>학부모 전화번호</span>
+                  <span className={infoValueStyle}>{detail.parent_phone || '-'}</span>
+                </div>
+                <div style={{ display: 'flex', gap: '16px' }}>
+                  <span className={infoLabelStyle}>소속 반</span>
+                  <span className={infoValueStyle}>
+                    {detail.classes.map((c) => c.name).join(', ') || '-'}
+                  </span>
+                </div>
+                <div style={{ display: 'flex', gap: '16px' }}>
+                  <span className={infoLabelStyle}>학교명</span>
+                  <span className={infoValueStyle}>{detail.school_name || '-'}</span>
+                </div>
+              </div>
             </div>
-          </div>
-        </>
+
+            {/* 통계 요약 */}
+            <div className={sectionStyle}>
+              <Text variant="headingMd" as="h3" className={sectionTitleStyle}>
+                통계 요약
+              </Text>
+              <div className={statsGridStyle}>
+                <div className={statCardStyle}>
+                  <span className={statLabelStyle}>완료율</span>
+                  <span className={statValueStyle} style={{ color: '#1DAA7F' }}>
+                    {detail.stats.completion_rate}%
+                  </span>
+                </div>
+                <div className={statCardStyle}>
+                  <span className={statLabelStyle}>완료</span>
+                  <span className={statValueStyle}>{detail.stats.total_complete_items}회</span>
+                </div>
+                <div className={statCardStyle}>
+                  <span className={statLabelStyle}>미완료</span>
+                  <span className={statValueStyle}>{detail.stats.total_incomplete_items}개</span>
+                </div>
+              </div>
+            </div>
+
+            {/* 추적 항목 */}
+            <div className={sectionStyle}>
+              <Text variant="headingMd" as="h3" className={sectionTitleStyle}>
+                추적 항목 <span style={{ color: '#3B51CC' }}>{detail.incomplete_items.length}</span>
+              </Text>
+              <div className={trackingListStyle}>
+                {detail.incomplete_items.length === 0 ? (
+                  <Text variant="bodyMd" color="gray500">
+                    미완료 항목이 없어요.
+                  </Text>
+                ) : (
+                  detail.incomplete_items.map((item: IncompleteItem) => (
+                    <div key={item.lesson_student_data_id} className={trackingItemStyle}>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                        <span className={trackingLabelStyle}>{item.item_name}</span>
+                        <span style={{ fontSize: '12px', color: '#9492A9' }}>
+                          {item.lesson_date} · {item.class_name}
+                        </span>
+                      </div>
+                      <button
+                        className={completeButtonStyle}
+                        onClick={() => handleComplete(item.lesson_student_data_id)}
+                      >
+                        <CheckIcon width={16} height={16} />
+                        완료 처리
+                      </button>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </>
+        )}
+      </Modal>
+
+      {detail && (
+        <AddStudentFormModal
+          isOpen={editStudent.isOpen}
+          onClose={editStudent.close}
+          mode="edit"
+          defaultValues={{
+            name: detail.name,
+            phone: detail.phone,
+            parent_phone: detail.parent_phone,
+            school_name: detail.school_name,
+            class_ids: detail.classes.map((c) => c.id),
+          }}
+          onConfirm={async (data) => {
+            try {
+              await studentService.updateStudent(detail.id, data)
+              // 수정 후 상세 다시 조회
+              const updated = await studentService.getStudent(detail.id)
+              setDetail(updated)
+              editStudent.close()
+              addToast({ variant: 'success', message: '학생 정보가 수정됐어요.' })
+              onUpdated?.()
+            } catch {
+              addToast({ variant: 'error', message: '학생 정보 수정에 실패했어요.' })
+            }
+          }}
+        />
       )}
-    </Modal>
+    </>
   )
 }


### PR DESCRIPTION
## 이슈 넘버

- close #45
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- `AddStudentFormModal`에 `mode`, `defaultValues` props 추가하여 수정 모드 지원
- 기본 정보 수정 버튼 클릭 시 수정 모달 오픈
- `PUT /api/v1/students/{id}` 연동
- 수정 후 상세 재조회로 즉시 반영
- 기본 정보 UI 개선 (한 컨테이너로 통합, 학교명 추가)

## 알려진 이슈
- 소속 반 수정 시 반영 안 됨 -> 백엔드 `class_ids` diff 반영 버그 수정 요청
