### PR TITLE
feat: 수업 데이터 API 연동

### DIFF
--- a/src/app/(main)/lesson/[id]/_components/MessagePreview/MessagePreview.tsx
+++ b/src/app/(main)/lesson/[id]/_components/MessagePreview/MessagePreview.tsx
@@ -4,7 +4,7 @@ import Dropdown from '@/components/common/Dropdown'
 import CloseIcon from '@/assets/icons/icon-close.svg'
 import { generateStudentMessage } from '@/lib/generateStudentMessage'
 import type { LessonStudent } from '@/types/lessonStudent'
-import { DEFAULT_LESSON_CONTEXT } from '@/hooks/useLessonDetail'
+import type { MessageContext } from '@/lib/generateStudentMessage'
 import {
   backdrop, drawer, drawerClosing, header, content,
   dropdownTrigger, messagePreview, closeButtonStyle,
@@ -15,10 +15,11 @@ interface MessagePreviewProps {
   onClose: () => void
   commonValues: Record<number, string>
   students: LessonStudent[]
+  context: MessageContext
 }
 
 export default function MessagePreview({
-  isOpen, onClose, commonValues, students
+  isOpen, onClose, commonValues, students, context
 }: MessagePreviewProps) {
   const [selectedStudentId, setSelectedStudentId] = useState<string>(String(students[0]?.id))
   const [isClosing, setIsClosing] = useState(false)
@@ -36,7 +37,6 @@ export default function MessagePreview({
     }
   }
 
-
   return (
     <div className={backdrop} onClick={handleClose}>
       <div
@@ -47,7 +47,7 @@ export default function MessagePreview({
         <div className={header}>
           <Text variant="headingMd">문자 미리보기</Text>
           <button onClick={handleClose} className={closeButtonStyle}>
-            <CloseIcon width={24} height={24}  />
+            <CloseIcon width={24} height={24} />
           </button>
         </div>
 
@@ -60,7 +60,7 @@ export default function MessagePreview({
           />
 
           <div className={messagePreview}>
-            {selectedStudent ? generateStudentMessage(selectedStudent, commonValues, DEFAULT_LESSON_CONTEXT) : ''}
+            {selectedStudent ? generateStudentMessage(selectedStudent, commonValues, context) : ''}
           </div>
         </div>
       </div>

--- a/src/app/(main)/lesson/[id]/page.tsx
+++ b/src/app/(main)/lesson/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { use } from 'react'
 import { useRouter } from 'next/navigation'
 import Text from '@/components/common/Text'
 import Button from '@/components/common/Button'
@@ -10,6 +11,7 @@ import MessageIcon from '@/assets/icons/icon-message.svg'
 import LessonTable from './_components/LessonTableSection/LessonTableSection'
 import CommonContent from './_components/CommonContent/CommonContent'
 import ProgressBar from './_components/ProgressBar/ProgressBar'
+import MessagePreview from './_components/MessagePreview/MessagePreview'
 import {
   pageStyle,
   headerStyle,
@@ -17,29 +19,49 @@ import {
   sectionStyle,
   templateSectionStyle,
   templateLabelRowStyle,
-  templateChipGroupStyle,
-  templateChipRecipe,
   backButtonStyle,
   headerLeftStyle,
   headerButtonGroupStyle,
 } from './lessonDetail.css'
-import MessagePreview from './_components/MessagePreview/MessagePreview'
-import { MOCK_LESSON_TEMPLATES, MOCK_COMMON_ITEMS } from '@/mocks/lesson'
-import useLessonDetail, { DEFAULT_LESSON_CONTEXT } from '@/hooks/useLessonDetail'
+import useLessonDetail from '@/hooks/useLessonDetail'
+import { lessonService } from '@/services/lesson'
+import { useToastStore } from '@/stores/toastStore'
+import { format } from 'date-fns'
+import { ko } from 'date-fns/locale'
 
-export default function LessonDetailPage() {
+export default function LessonDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  const lessonId = Number(id)
   const router = useRouter()
+  const addToast = useToastStore((s) => s.addToast)
+
   const {
-    selectedTemplateId,
-    setSelectedTemplateId,
+    lesson,
+    template,
     commonValues,
     setCommonValues,
     students,
     setStudents,
     messagePreview,
     inputCount,
+    isLoading,
     handleExcelDownload,
-  } = useLessonDetail()
+  } = useLessonDetail(lessonId)
+
+  const handleSave = async () => {
+    try {
+      await lessonService.saveLesson(lessonId)
+      addToast({ variant: 'success', message: '저장됐어요.' })
+    } catch {
+      addToast({ variant: 'error', message: '저장에 실패했어요.' })
+    }
+  }
+
+  if (isLoading || !lesson || !template) return null
+
+  const commonItems = template.items
+    .filter((i) => i.is_common)
+    .map((i) => ({ id: i.id, label: i.name }))
 
   return (
     <div className={pageStyle}>
@@ -50,7 +72,7 @@ export default function LessonDetailPage() {
             <ArrowLeftIcon width={24} height={24} />
           </button>
           <Text variant="display" as="h1">
-            {DEFAULT_LESSON_CONTEXT.lessonDate} {DEFAULT_LESSON_CONTEXT.className}
+            {format(new Date(lesson.lesson_date), 'M월 d일(E)', { locale: ko })} {lesson.class_name}
           </Text>
         </div>
         <div className={headerButtonGroupStyle}>
@@ -62,42 +84,39 @@ export default function LessonDetailPage() {
           >
             엑셀 다운로드
           </Button>
-          <Button variant="primary" size="sm" leftIcon={<SaveIcon width={20} height={20} />}>
+          <Button
+            variant="primary"
+            size="sm"
+            leftIcon={<SaveIcon width={20} height={20} />}
+            onClick={handleSave}
+            disabled={lesson.status === 'SAVED'}
+          >
             저장
           </Button>
         </div>
       </div>
 
-      {/* 템플릿 선택 */}
+      {/* 템플릿 정보 */}
       <div className={templateSectionStyle}>
         <div className={templateLabelRowStyle}>
           <Text variant="headingMd">템플릿</Text>
           <Text variant="bodyMd" color="gray500">
-            오늘 수업에 적용할 템플릿을 선택해주세요
+            {template.name}
           </Text>
-        </div>
-        <div className={templateChipGroupStyle}>
-          {MOCK_LESSON_TEMPLATES.map((t) => (
-            <button
-              key={t.id}
-              className={templateChipRecipe({ selected: selectedTemplateId === t.id })}
-              onClick={() => setSelectedTemplateId(t.id)}
-            >
-              {t.name}
-            </button>
-          ))}
         </div>
       </div>
 
       {/* 공통 내용 */}
-      <div className={sectionStyle}>
-        <Text variant="headingMd">공통 내용</Text>
-        <CommonContent
-          items={MOCK_COMMON_ITEMS}
-          values={commonValues}
-          onChange={(id, value) => setCommonValues((prev) => ({ ...prev, [id]: value }))}
-        />
-      </div>
+      {commonItems.length > 0 && (
+        <div className={sectionStyle}>
+          <Text variant="headingMd">공통 내용</Text>
+          <CommonContent
+            items={commonItems}
+            values={commonValues}
+            onChange={(id, value) => setCommonValues((prev) => ({ ...prev, [id]: value }))}
+          />
+        </div>
+      )}
 
       {/* 개별 내용 */}
       <div className={sectionStyle}>
@@ -123,6 +142,12 @@ export default function LessonDetailPage() {
         onClose={messagePreview.close}
         commonValues={commonValues}
         students={students}
+        context={{
+          academyName: lesson.academy_name,
+          teacherName: '',
+          className: lesson.class_name,
+          lessonDate: format(new Date(lesson.lesson_date), 'M월 d일(E)', { locale: ko }),
+        }}
       />
     </div>
   )

--- a/src/app/(main)/lesson/_components/AddLessonModal/AddLessonModal.tsx
+++ b/src/app/(main)/lesson/_components/AddLessonModal/AddLessonModal.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { format } from 'date-fns'
 import { ko } from 'date-fns/locale'
 import Text from '@/components/common/Text'
 import Button from '@/components/common/Button'
 import Modal from '@/components/common/Modal'
 import Chip from '@/components/common/Chip'
-import PlusCircleIcon from '@/assets/icons/icon-plus-circle.svg'
+import { classService, type Class } from '@/services/class'
 import {
   headerStyle,
   classListStyle,
@@ -19,7 +19,10 @@ import {
   radioSelectedStyle,
   actionsStyle,
 } from './AddLessonModal.css'
-import { MOCK_LESSON_CLASSES } from '@/mocks/lesson'
+
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토']
+const formatSchedule = (schedules: { day_of_week: number }[]) =>
+  schedules.map((s) => DAY_NAMES[s.day_of_week]).join('·')
 
 interface AddLessonModalProps {
   isOpen: boolean
@@ -35,6 +38,14 @@ export default function AddLessonModal({
   selectedDate,
 }: AddLessonModalProps) {
   const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [classes, setClasses] = useState<Class[]>([])
+
+  useEffect(() => {
+    if (!isOpen) return
+    classService.getClasses({ status: 'active' })
+      .then((res) => setClasses(res.data))
+      .catch((err) => console.error('반 목록 조회 실패', err))
+  }, [isOpen])
 
   const handleClose = () => {
     setSelectedId(null)
@@ -50,7 +61,7 @@ export default function AddLessonModal({
         </Text>
       </div>
       <div className={classListStyle}>
-        {MOCK_LESSON_CLASSES.map((cls) => {
+        {classes.map((cls) => {
           const isSelected = selectedId === cls.id
           return (
             <div
@@ -61,8 +72,8 @@ export default function AddLessonModal({
               <div className={`${radioStyle}${isSelected ? ` ${radioSelectedStyle}` : ''}`} />
               <span className={classNameStyle}>{cls.name}</span>
               <div className={classMetaStyle}>
-                <Chip label={cls.academyName} />
-                <Chip label={cls.schedule} />
+                <Chip label={cls.academy_name} />
+                <Chip label={formatSchedule(cls.schedules)} />
               </div>
             </div>
           )

--- a/src/app/(main)/lesson/new/page.tsx
+++ b/src/app/(main)/lesson/new/page.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { use, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
+import Text from '@/components/common/Text'
+import Button from '@/components/common/Button'
+import ArrowLeftIcon from '@/assets/icons/icon-arrow-left.svg'
+import { templateService } from '@/services/template'
+import { lessonService } from '@/services/lesson'
+import { useToastStore } from '@/stores/toastStore'
+import type { Template } from '@/services/template'
+import {
+  pageStyle,
+  headerStyle,
+  backButtonStyle,
+  headerLeftStyle,
+  templateSectionStyle,
+  templateLabelRowStyle,
+  templateChipGroupStyle,
+  templateChipRecipe,
+} from '../[id]/lessonDetail.css'
+
+function LessonNewContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const classId = Number(searchParams.get('class_id'))
+  const date = searchParams.get('date') ?? ''
+  const addToast = useToastStore((s) => s.addToast)
+
+  const [templates, setTemplates] = useState<Template[]>([])
+  const [selectedTemplateId, setSelectedTemplateId] = useState<number | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    templateService.getTemplates().then((res) => {
+      setTemplates(res)
+      if (res.length > 0) setSelectedTemplateId(res[0].id)  // 첫 번째 자동 선택
+    })
+  }, [])
+
+  const handleCreate = async () => {
+    if (!selectedTemplateId) return
+    setIsLoading(true)
+    try {
+      const lesson = await lessonService.createLesson({
+        class_id: classId,
+        template_id: selectedTemplateId,
+        lesson_date: date,
+        is_adhoc: true,
+        status: 'DRAFT',
+        common_data: [],
+        student_data: [],
+      })
+      router.push(`/lesson/${lesson.id}`)
+    } catch {
+      addToast({ variant: 'error', message: '수업 생성에 실패했어요.' })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleSelectTemplate = async (templateId: number) => {
+    setSelectedTemplateId(templateId)
+    setIsLoading(true)
+    try {
+      const lesson = await lessonService.createLesson({
+        class_id: classId,
+        template_id: templateId,
+        lesson_date: date,
+        is_adhoc: true,
+        status: 'DRAFT',
+        common_data: [],
+        student_data: [],
+      })
+      router.push(`/lesson/${lesson.id}`)
+    } catch {
+      addToast({ variant: 'error', message: '수업 생성에 실패했어요.' })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className={pageStyle}>
+      <div className={headerStyle}>
+        <div className={headerLeftStyle}>
+          <button onClick={() => router.back()} className={backButtonStyle}>
+            <ArrowLeftIcon width={24} height={24} />
+          </button>
+          <Text variant="display" as="h1">수업 추가</Text>
+        </div>
+      </div>
+
+      <div className={templateSectionStyle}>
+        <div className={templateLabelRowStyle}>
+          <Text variant="headingMd">템플릿</Text>
+          <Text variant="bodyMd" color="gray500">
+            수업에 적용할 템플릿을 선택해주세요
+          </Text>
+        </div>
+        <div className={templateChipGroupStyle}>
+          {templates.map((t) => (
+            <button
+              key={t.id}
+              className={templateChipRecipe({ selected: selectedTemplateId === t.id })}
+              onClick={() => handleSelectTemplate(t.id)}
+            >
+              {t.name}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function LessonNewPage() {
+  return (
+    <Suspense>
+      <LessonNewContent />
+    </Suspense>
+  )
+}

--- a/src/app/(main)/lesson/page.tsx
+++ b/src/app/(main)/lesson/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { startOfWeek, addWeeks, subWeeks, format, addDays, isSameDay } from 'date-fns'
 import { ko } from 'date-fns/locale'
@@ -20,7 +20,7 @@ import {
   navButtonStyle,
   weekNavStyle,
 } from './lesson.css'
-import { MOCK_LESSONS } from '@/mocks/lesson'
+import { lessonService, type LessonSummary } from '@/services/lesson'
 
 const DAYS_KO = ['월', '화', '수', '목', '금', '토', '일']
 
@@ -29,6 +29,17 @@ export default function LessonPage() {
   const [currentWeek, setCurrentWeek] = useState(new Date())
   const [selectedDate, setSelectedDate] = useState(new Date())
   const [isAddLessonOpen, setIsAddLessonOpen] = useState(false)
+  const [lessons, setLessons] = useState<LessonSummary[]>([])
+  const [isLoadingLessons, setIsLoadingLessons] = useState(false)
+
+  useEffect(() => {
+    setIsLoadingLessons(true)
+    lessonService
+      .getLessons(format(selectedDate, 'yyyy-MM-dd'))
+      .then((res) => setLessons(res.data))
+      .catch((err) => console.error('수업 목록 조회 실패', err))
+      .finally(() => setIsLoadingLessons(false))
+  }, [selectedDate])
 
   const weekStart = startOfWeek(currentWeek, { weekStartsOn: 1 })
 
@@ -81,11 +92,17 @@ export default function LessonPage() {
         <Text variant="headingMd">{selectedLabel}</Text>
       </div>
       <div className={lessonGridStyle}>
-        {MOCK_LESSONS.map((lesson) => (
+        {lessons.map((lesson) => (
           <LessonCard
-            key={lesson.id}
-            {...lesson}
-            onClick={() => router.push(`/lesson/${lesson.id}`)}
+            key={lesson.lesson_record_id}
+            academyName={lesson.academy_name}
+            templateName={lesson.template_name}
+            className={lesson.class_name}
+            progress={lesson.progress_rate}
+            totalStudents={0}
+            inputCount={0}
+            isDone={lesson.status === 'SAVED'}
+            onClick={() => router.push(`/lesson/${lesson.lesson_record_id}`)}
           />
         ))}
         <AddCard
@@ -98,7 +115,11 @@ export default function LessonPage() {
         <AddLessonModal
           isOpen={isAddLessonOpen}
           onClose={() => setIsAddLessonOpen(false)}
-          onConfirm={(id) => console.log('수업 추가', id)}
+          onConfirm={(classId) => {
+            router.push(
+              `/lesson/new?class_id=${classId}&date=${format(selectedDate, 'yyyy-MM-dd')}`
+            )
+          }}
           selectedDate={selectedDate}
         />
       </div>

--- a/src/hooks/useLessonDetail.ts
+++ b/src/hooks/useLessonDetail.ts
@@ -1,51 +1,71 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import type { LessonStudent } from '@/types/lessonStudent'
-import type { MessageContext } from '@/lib/generateStudentMessage'
+import { lessonService, type LessonDetail } from '@/services/lesson'
+import { templateService, type TemplateDetail } from '@/services/template'
 import { exportLessonExcel } from '@/lib/exportExcel'
-import { MOCK_COMMON_ITEMS, MOCK_LESSON_STUDENTS } from '@/mocks/lesson'
 import useDisclosure from './useDisclosure'
 
-// API 연동 전까지 페이지 수준에서 주입되는 수업 컨텍스트
-export const DEFAULT_LESSON_CONTEXT: MessageContext = {
-  academyName: '엘리에듀학원',
-  teacherName: '윤준용',
-  className: '미적분 A반',
-  lessonDate: '2월 20일(금)',
-}
-
-export default function useLessonDetail() {
-  const [selectedTemplateId, setSelectedTemplateId] = useState(1)
+export default function useLessonDetail(lessonId: number) {
+  const [lesson, setLesson] = useState<LessonDetail | null>(null)
+  const [template, setTemplate] = useState<TemplateDetail | null>(null)
   const [commonValues, setCommonValues] = useState<Record<number, string>>({})
-  const [students, setStudents] = useState<LessonStudent[]>(MOCK_LESSON_STUDENTS)
+  const [students, setStudents] = useState<LessonStudent[]>([])
+  const [isLoading, setIsLoading] = useState(true)
   const messagePreview = useDisclosure()
 
-  const inputCount = students.filter(
-    (s) =>
-      s.attendance !== null &&
-      s.homework !== null &&
-      s.answerNote !== null &&
-      s.score !== '',
+  useEffect(() => {
+    if (!lessonId) return
+    setIsLoading(true)
+    lessonService
+      .getLesson(lessonId)
+      .then(async (data) => {
+        setLesson(data)
+        // common_data 초기값 세팅
+        const values: Record<number, string> = {}
+        data.common_data.forEach((item) => {
+          values[item.template_item_id] = item.value
+        })
+        setCommonValues(values)
+        // 템플릿 상세 조회
+        const tmpl = await templateService.getTemplate(data.template_id)
+        setTemplate(tmpl)
+      })
+      .finally(() => setIsLoading(false))
+  }, [lessonId])
+
+  const inputCount = students.filter((s) =>
+    s.attendance !== null &&
+    s.homework !== null &&
+    s.answerNote !== null &&
+    s.score !== ''
   ).length
 
   const handleExcelDownload = () => {
+    if (!lesson || !template) return
     exportLessonExcel({
-      title: `${DEFAULT_LESSON_CONTEXT.lessonDate} ${DEFAULT_LESSON_CONTEXT.className} 수업 결과`,
-      commonItems: MOCK_COMMON_ITEMS,
+      title: `${lesson.lesson_date} 수업 결과`,
+      commonItems: template.items.filter((i) => i.is_common).map((i) => ({ id: i.id, label: i.name })),
       commonValues,
       students,
-      context: DEFAULT_LESSON_CONTEXT,
+      context: {
+        academyName: '',
+        teacherName: '',
+        className: '',
+        lessonDate: lesson.lesson_date,
+      },
     })
   }
 
   return {
-    selectedTemplateId,
-    setSelectedTemplateId,
+    lesson,
+    template,
     commonValues,
     setCommonValues,
     students,
     setStudents,
     messagePreview,
     inputCount,
+    isLoading,
     handleExcelDownload,
   }
 }

--- a/src/services/lesson.ts
+++ b/src/services/lesson.ts
@@ -12,6 +12,20 @@ export interface LessonSummary {
   is_adhoc: boolean
 }
 
+export interface LessonDetail {
+  id: number
+  class_id: number
+  class_name: string
+  academy_name: string
+  template_id: number
+  template_name: string
+  lesson_date: string
+  status: 'DRAFT' | 'SAVED'
+  is_adhoc: boolean
+  common_data: CommonDataItem[]
+  student_data: StudentData[]
+}
+
 export interface LessonListResponse {
   data: LessonSummary[]
   meta: { total: number }
@@ -56,7 +70,7 @@ export const lessonService = {
     return data.data
   },
 
-  async getLesson(id: number): Promise<any> {
+  async getLesson(id: number): Promise<LessonDetail> {
     const { data } = await axiosInstance.get(`/lessons/${id}`)
     return data.data
   },

--- a/src/services/lesson.ts
+++ b/src/services/lesson.ts
@@ -1,0 +1,89 @@
+import axiosInstance from '@/lib/api/axiosInstance'
+
+export interface LessonSummary {
+  lesson_record_id: number
+  class_id: number
+  class_name: string
+  academy_name: string
+  template_id: number
+  template_name: string
+  progress_rate: number
+  status: 'DRAFT' | 'SAVED'
+  is_adhoc: boolean
+}
+
+export interface LessonListResponse {
+  data: LessonSummary[]
+  meta: { total: number }
+}
+
+export interface CommonDataItem {
+  template_item_id: number
+  value: string
+}
+
+export interface StudentDataItem {
+  template_item_id: number
+  value: string
+  is_completed?: boolean
+}
+
+export interface StudentData {
+  student_id: number
+  items: StudentDataItem[]
+}
+
+export interface CreateLessonDto {
+  class_id: number
+  template_id: number
+  lesson_date: string
+  is_adhoc: boolean
+  status: 'DRAFT' | 'SAVED'
+  common_data: CommonDataItem[]
+  student_data: StudentData[]
+}
+
+export interface UpdateLessonDto {
+  template_id?: number
+  status?: 'DRAFT' | 'SAVED'
+  common_data: CommonDataItem[]
+  student_data: StudentData[]
+}
+
+export const lessonService = {
+  async getLessons(date: string): Promise<LessonListResponse> {
+    const { data } = await axiosInstance.get('/lessons', { params: { date } })
+    return data.data
+  },
+
+  async getLesson(id: number): Promise<any> {
+    const { data } = await axiosInstance.get(`/lessons/${id}`)
+    return data.data
+  },
+
+  async createLesson(dto: CreateLessonDto): Promise<any> {
+    const { data } = await axiosInstance.post('/lessons', dto)
+    return data.data
+  },
+
+  async updateLesson(id: number, dto: UpdateLessonDto): Promise<any> {
+    const { data } = await axiosInstance.put(`/lessons/${id}`, dto)
+    return data.data
+  },
+
+  async saveLesson(id: number): Promise<void> {
+    await axiosInstance.post(`/lessons/${id}/save`)
+  },
+
+  async previewLesson(id: number): Promise<any> {
+    const { data } = await axiosInstance.get(`/lessons/${id}/preview`)
+    return data.data
+  },
+
+  async exportLesson(id: number): Promise<Blob> {
+    const { data } = await axiosInstance.get(`/lessons/${id}/export`, {
+      responseType: 'blob',
+    })
+    return data
+  },
+}


### PR DESCRIPTION
## 이슈 넘버

- close #47 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- `services/lesson.ts` 신규 생성
- 날짜별 수업 목록 조회 `GET /api/v1/lessons` 연동
- 수업 생성 `POST /api/v1/lessons` 연동
- 수업 상세 조회 `GET /api/v1/lessons/{id}` 연동
- 저장 `POST /api/v1/lessons/{id}/save` 연동
- `/lesson/new` 페이지 신규 생성 (반 선택 후 템플릿 선택 시 수업 생성)
- `useLessonDetail` hook mock 제거 및 API 기반으로 수정
- `MessagePreview` `context` props 추가