### PR TITLE
feat: 수업 입력 API 연동 및 UX 개선

### DIFF
--- a/src/app/(main)/lesson/[id]/_components/LessonTableSection/LessonTableSection.tsx
+++ b/src/app/(main)/lesson/[id]/_components/LessonTableSection/LessonTableSection.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import CheckIcon from '@/assets/icons/icon-check.svg'
+import type { LessonStudent, Attendance, CompletionStatus } from '@/types/lessonStudent'
+import type { TemplateItemDetail } from '@/services/template'
 import {
   tableStyle,
   thStyle,
@@ -19,11 +21,10 @@ import {
   activeRowStyle,
 } from './LessonTable.css'
 
-import type { LessonStudent as Student, Attendance, CompletionStatus } from '@/types/lessonStudent'
-
 interface LessonTableSectionProps {
-  students: Student[]
-  onChange: (students: Student[]) => void
+  students: LessonStudent[]
+  templateItems: TemplateItemDetail[]
+  onChange: (students: LessonStudent[]) => void
 }
 
 function AttendanceCell({
@@ -82,23 +83,28 @@ function CompletionCell({
   )
 }
 
-export default function LessonTable({ students, onChange }: LessonTableSectionProps) {
-  const updateStudent = (id: number, field: keyof Student, value: unknown) => {
-    onChange(students.map((s) => (s.id === id ? { ...s, [field]: value } : s)))
+export default function LessonTable({ students, templateItems, onChange }: LessonTableSectionProps) {
+  const dynamicItems = templateItems.filter((i) => !i.is_common && !i.is_default_attendance)
+
+  const updateAttendance = (studentId: number, value: Attendance) => {
+    onChange(students.map((s) => s.id === studentId ? { ...s, attendance: value } : s))
+  }
+
+  const updateItem = (studentId: number, templateItemId: number, value: string, is_completed?: boolean | null) => {
+    onChange(students.map((s) => {
+      if (s.id !== studentId) return s
+      const items = s.items.map((item) =>
+        item.template_item_id === templateItemId
+          ? { ...item, value, is_completed: is_completed ?? item.is_completed }
+          : item
+      )
+      return { ...s, items }
+    }))
   }
 
   const allAttend = students.every((s) => s.attendance === '출석')
-  const allHomework = students.every((s) => s.homework === '완료')
-  const allAnswerNote = students.every((s) => s.answerNote === '완료')
-
   const handleAllAttend = (checked: boolean) => {
     onChange(students.map((s) => ({ ...s, attendance: checked ? '출석' : null })))
-  }
-  const handleAllHomework = (checked: boolean) => {
-    onChange(students.map((s) => ({ ...s, homework: checked ? '완료' : null })))
-  }
-  const handleAllAnswerNote = (checked: boolean) => {
-    onChange(students.map((s) => ({ ...s, answerNote: checked ? '완료' : null })))
   }
 
   return (
@@ -118,86 +124,57 @@ export default function LessonTable({ students, onChange }: LessonTableSectionPr
               </div>
             </div>
           </th>
-          <th className={thShrinkStyle}>
-            <div className={thInnerStyle}>
-              과제
-              <div
-                className={`${checkboxLabelStyle}${allHomework ? ` ${checkboxLabelActiveStyle}` : ''}`}
-                onClick={() => handleAllHomework(!allHomework)}
-              >
-                <CheckIcon width={14} height={14} />
-                전체 완료
-              </div>
-            </div>
-          </th>
-          <th className={thShrinkStyle}>
-            <div className={thInnerStyle}>
-              오답노트
-              <div
-                className={`${checkboxLabelStyle}${allAnswerNote ? ` ${checkboxLabelActiveStyle}` : ''}`}
-                onClick={() => handleAllAnswerNote(!allAnswerNote)}
-              >
-                <CheckIcon width={14} height={14} />
-                전체 완료
-              </div>
-            </div>
-          </th>
-          <th className={thShrinkStyle}>시험 점수</th>
-          <th className={thStyle}>메모</th>
+          {dynamicItems.map((item) => (
+            <th key={item.id} className={thShrinkStyle}>{item.name}</th>
+          ))}
         </tr>
       </thead>
       <tbody>
         {students.map((student) => (
-          <tr
-            key={student.id}
-            className={
-              student.attendance !== null &&
-              student.homework !== null &&
-              student.answerNote !== null &&
-              student.score !== ''
-                ? activeRowStyle
-                : undefined
-            }
-          >
+          <tr key={student.id}>
             <td className={tdCompactStyle}>
               <span className={nameCellStyle}>{student.name}</span>
             </td>
             <td className={tdCompactStyle}>
               <AttendanceCell
                 value={student.attendance}
-                onChange={(v) => updateStudent(student.id, 'attendance', v)}
+                onChange={(v) => updateAttendance(student.id, v)}
               />
             </td>
-            <td className={tdShrinkStyle}>
-              <CompletionCell
-                value={student.homework}
-                onChange={(v) => updateStudent(student.id, 'homework', v)}
-              />
-            </td>
-            <td className={tdShrinkStyle}>
-              <CompletionCell
-                value={student.answerNote}
-                onChange={(v) => updateStudent(student.id, 'answerNote', v)}
-              />
-            </td>
-            <td className={tdShrinkStyle}>
-              <div
-                contentEditable
-                suppressContentEditableWarning
-                className={cellEditableStyle}
-                onBlur={(e) => updateStudent(student.id, 'score', e.currentTarget.textContent ?? '')}
-                dangerouslySetInnerHTML={{ __html: student.score }}
-              />
-            </td>
-            <td className={tdStyle}>
-              <div
-                contentEditable
-                suppressContentEditableWarning
-                className={cellEditableStyle}
-                onBlur={(e) => updateStudent(student.id, 'memo', e.currentTarget.textContent ?? '')}
-                dangerouslySetInnerHTML={{ __html: student.memo }}
-              />
-            </td>
+            {dynamicItems.map((item) => {
+              const studentItem = student.items.find((i) => i.template_item_id === item.id)
+              if (item.item_type === 'COMPLETE') {
+                const status: CompletionStatus = studentItem?.is_completed === true
+                  ? '완료'
+                  : studentItem?.is_completed === false
+                  ? '미완료'
+                  : null
+                return (
+                  <td key={item.id} className={tdShrinkStyle}>
+                    <CompletionCell
+                      value={status}
+                      onChange={(v) => updateItem(
+                        student.id,
+                        item.id,
+                        v ?? '',
+                        v === '완료' ? true : v === '미완료' ? false : null
+                      )}
+                    />
+                  </td>
+                )
+              }
+              return (
+                <td key={item.id} className={tdStyle}>
+                  <div
+                    contentEditable
+                    suppressContentEditableWarning
+                    className={cellEditableStyle}
+                    onBlur={(e) => updateItem(student.id, item.id, e.currentTarget.textContent ?? '')}
+                    dangerouslySetInnerHTML={{ __html: studentItem?.value ?? '' }}
+                  />
+                </td>
+              )
+            })}
           </tr>
         ))}
       </tbody>

--- a/src/app/(main)/lesson/[id]/_components/MessagePreview/MessagePreview.tsx
+++ b/src/app/(main)/lesson/[id]/_components/MessagePreview/MessagePreview.tsx
@@ -1,32 +1,47 @@
-import { useState } from 'react'
+'use client'
+
+import { useEffect, useState } from 'react'
 import Text from '@/components/common/Text'
 import Dropdown from '@/components/common/Dropdown'
 import CloseIcon from '@/assets/icons/icon-close.svg'
-import { generateStudentMessage } from '@/lib/generateStudentMessage'
-import type { LessonStudent } from '@/types/lessonStudent'
-import type { MessageContext } from '@/lib/generateStudentMessage'
+import { lessonService } from '@/services/lesson'
 import {
   backdrop, drawer, drawerClosing, header, content,
   dropdownTrigger, messagePreview, closeButtonStyle,
 } from './MessagePreview.css'
 
+interface PreviewStudent {
+  student_id: number
+  student_name: string
+  phone: string
+  parent_phone: string
+  message: string
+}
+
 interface MessagePreviewProps {
   isOpen: boolean
   onClose: () => void
-  commonValues: Record<number, string>
-  students: LessonStudent[]
-  context: MessageContext
+  lessonId: number
 }
 
-export default function MessagePreview({
-  isOpen, onClose, commonValues, students, context
-}: MessagePreviewProps) {
-  const [selectedStudentId, setSelectedStudentId] = useState<string>(String(students[0]?.id))
+export default function MessagePreview({ isOpen, onClose, lessonId }: MessagePreviewProps) {
+  const [students, setStudents] = useState<PreviewStudent[]>([])
+  const [selectedStudentId, setSelectedStudentId] = useState<string>('')
   const [isClosing, setIsClosing] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) return
+    lessonService.previewLesson(lessonId).then((res) => {
+      setStudents(res.data)
+      if (res.data.length > 0) {
+        setSelectedStudentId(String(res.data[0].student_id))
+      }
+    })
+  }, [isOpen, lessonId])
 
   if (!isOpen && !isClosing) return null
 
-  const selectedStudent = students.find(s => String(s.id) === selectedStudentId)
+  const selectedStudent = students.find((s) => String(s.student_id) === selectedStudentId)
 
   const handleClose = () => setIsClosing(true)
 
@@ -53,14 +68,14 @@ export default function MessagePreview({
 
         <div className={content}>
           <Dropdown
-            options={students.map(s => ({ label: s.name, value: String(s.id) }))}
+            options={students.map((s) => ({ label: s.student_name, value: String(s.student_id) }))}
             value={selectedStudentId}
             onChange={setSelectedStudentId}
             triggerClassName={dropdownTrigger}
+            noBorder
           />
-
           <div className={messagePreview}>
-            {selectedStudent ? generateStudentMessage(selectedStudent, commonValues, context) : ''}
+            {selectedStudent?.message ?? ''}
           </div>
         </div>
       </div>

--- a/src/app/(main)/lesson/[id]/lessonDetail.css.ts
+++ b/src/app/(main)/lesson/[id]/lessonDetail.css.ts
@@ -134,3 +134,24 @@ export const templateChipRecipe = recipe({
     selected: false,
   },
 })
+
+export const templateChipButtonStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  padding: '8px 12px',
+  borderRadius: '8px',
+  border: 'none',
+  backgroundColor: colors.gray50,
+  color: colors.gray500,
+  fontSize: fontStyles.titleSm.fontSize,
+  fontWeight: fontStyles.titleSm.fontWeight,
+  cursor: 'pointer',
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+  selectors: {
+    '&:hover': {
+      backgroundColor: colors.gray75,
+    },
+  },
+})

--- a/src/app/(main)/lesson/[id]/lessonDetail.css.ts
+++ b/src/app/(main)/lesson/[id]/lessonDetail.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style, keyframes } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 import { colors } from '@/styles/tokens/colors'
 import { fontStyles } from '@/styles/tokens/typography'
@@ -71,6 +71,37 @@ export const templateLabelRowStyle = style({
 export const templateChipGroupStyle = style({
   display: 'flex',
   gap: '8px',
+})
+
+const shimmer = keyframes({
+  '0%, 100%': { opacity: 1 },
+  '50%': { opacity: 0.4 },
+})
+
+export const skeletonSectionStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '20px',
+})
+
+export const skeletonTableStyle = style({
+  width: '100%',
+  borderRadius: '8px',
+  overflow: 'hidden',
+  border: `1px solid ${colors.gray100}`,
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+export const skeletonRowStyle = style({
+  height: '48px',
+  backgroundColor: colors.gray100,
+  animation: `${shimmer} 1.5s ease-in-out infinite`,
+  selectors: {
+    '& + &': {
+      borderTop: `1px solid ${colors.white}`,
+    },
+  },
 })
 
 export const templateChipRecipe = recipe({

--- a/src/app/(main)/lesson/[id]/page.tsx
+++ b/src/app/(main)/lesson/[id]/page.tsx
@@ -7,7 +7,6 @@ import Button from '@/components/common/Button'
 import ArrowLeftIcon from '@/assets/icons/icon-arrow-left.svg'
 import DownloadIcon from '@/assets/icons/icon-download.svg'
 import SaveIcon from '@/assets/icons/icon-save.svg'
-import EditIcon from '@/assets/icons/icon-edit.svg'
 import ChevronDownIcon from '@/assets/icons/icon-chevron-down.svg'
 import MessageIcon from '@/assets/icons/icon-message.svg'
 import LessonTable from './_components/LessonTableSection/LessonTableSection'
@@ -21,8 +20,6 @@ import {
   headerStyle,
   footerStyle,
   sectionStyle,
-  templateSectionStyle,
-  templateLabelRowStyle,
   backButtonStyle,
   headerLeftStyle,
   headerButtonGroupStyle,
@@ -44,6 +41,7 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
   const {
     lesson,
     template,
+    error,
     commonValues,
     setCommonValues,
     students,
@@ -63,7 +61,6 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
     if (!lesson || !template) return
     try {
       const attendanceItem = template.items.find((i) => i.is_default_attendance)
-
       await lessonService.updateLesson({
         lesson_id: lessonId,
         class_id: lesson.class_id,
@@ -94,7 +91,6 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
           ],
         })),
       })
-
       addToast({ variant: 'success', message: '저장됐어요.' })
     } catch {
       addToast({ variant: 'error', message: '저장에 실패했어요.' })
@@ -107,15 +103,17 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
     confirmModal.open()
   }
 
-  const handleTemplateChange = async () => {
-    if (!lesson || !pendingTemplateId) return
+  const handleTemplateChange = async (templateId?: number) => {
+    const targetId = templateId ?? pendingTemplateId
+    if (!lesson || !targetId) return
     confirmModal.close()
+    templateModal.close()
     try {
       await lessonService.updateLesson({
         lesson_id: lessonId,
         class_id: lesson.class_id,
         lesson_date: lesson.lesson_date,
-        template_id: pendingTemplateId,
+        template_id: targetId,
         status: 'DRAFT',
         common_data: [],
         student_data: students.map((s) => ({ student_id: s.id, items: [] })),
@@ -128,7 +126,54 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
     }
   }
 
-  if (isLoading || !lesson || !template) return null
+  if (isLoading || !lesson) return null
+
+  // 템플릿 삭제된 경우
+  if (error === 'TEMPLATE_NOT_FOUND') {
+    return (
+      <div className={pageStyle}>
+        <div className={headerStyle}>
+          <div className={headerLeftStyle}>
+            <button onClick={() => router.push('/lesson')} className={backButtonStyle}>
+              <ArrowLeftIcon width={24} height={24} />
+            </button>
+            <Text variant="display" as="h1">
+              {format(new Date(lesson.lesson_date), 'M월 d일(E)', { locale: ko })}{' '}
+              {lesson.class_name}
+            </Text>
+          </div>
+        </div>
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '16px',
+            minHeight: 'calc(100vh - 300px)',
+          }}
+        >
+          <Text variant="headingMd">템플릿이 삭제됐어요</Text>
+          <Text variant="bodyLg" color="gray500">
+            다른 템플릿을 선택해주세요
+          </Text>
+          <Button variant="primary" size="md" onClick={templateModal.open}>
+            템플릿 선택
+          </Button>
+        </div>
+        <TemplateSelectModal
+          isOpen={templateModal.isOpen}
+          onClose={templateModal.close}
+          onConfirm={handleTemplateChange}
+          title="템플릿 선택"
+          confirmLabel="선택"
+        />
+      </div>
+    )
+  }
+
+  if (!template) return null
 
   const commonItems = template.items
     .filter((i) => i.is_common)
@@ -206,19 +251,6 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
         </Button>
       </div>
 
-      <MessagePreview
-        isOpen={messagePreview.isOpen}
-        onClose={messagePreview.close}
-        commonValues={commonValues}
-        students={students}
-        context={{
-          academyName: lesson.academy_name,
-          teacherName: '',
-          className: lesson.class_name,
-          lessonDate: format(new Date(lesson.lesson_date), 'M월 d일(E)', { locale: ko }),
-        }}
-      />
-
       <TemplateSelectModal
         isOpen={templateModal.isOpen}
         onClose={templateModal.close}
@@ -234,11 +266,17 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
           confirmModal.close()
           setPendingTemplateId(null)
         }}
-        onConfirm={handleTemplateChange}
+        onConfirm={() => handleTemplateChange()}
         title="템플릿을 변경할까요?"
         descriptions={['템플릿을 변경하면 입력한 내용이 모두 사라져요.']}
         confirmLabel="변경"
         confirmVariant="danger"
+      />
+
+      <MessagePreview
+        isOpen={messagePreview.isOpen}
+        onClose={messagePreview.close}
+        lessonId={lessonId}
       />
     </div>
   )

--- a/src/app/(main)/lesson/[id]/page.tsx
+++ b/src/app/(main)/lesson/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { use } from 'react'
+import { use, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Text from '@/components/common/Text'
 import Button from '@/components/common/Button'
@@ -12,6 +12,8 @@ import LessonTable from './_components/LessonTableSection/LessonTableSection'
 import CommonContent from './_components/CommonContent/CommonContent'
 import ProgressBar from './_components/ProgressBar/ProgressBar'
 import MessagePreview from './_components/MessagePreview/MessagePreview'
+import ConfirmModal from '@/components/common/ConfirmModal'
+import TemplateSelectModal from '../_components/TemplateSelectModal/TemplateSelectModal'
 import {
   pageStyle,
   headerStyle,
@@ -24,6 +26,7 @@ import {
   headerButtonGroupStyle,
 } from './lessonDetail.css'
 import useLessonDetail from '@/hooks/useLessonDetail'
+import useDisclosure from '@/hooks/useDisclosure'
 import { lessonService } from '@/services/lesson'
 import { useToastStore } from '@/stores/toastStore'
 import { format } from 'date-fns'
@@ -46,14 +49,79 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
     inputCount,
     isLoading,
     handleExcelDownload,
+    refetch,
   } = useLessonDetail(lessonId)
 
+  const templateModal = useDisclosure()
+  const confirmModal = useDisclosure()
+  const [pendingTemplateId, setPendingTemplateId] = useState<number | null>(null)
+
   const handleSave = async () => {
+    if (!lesson || !template) return
     try {
-      await lessonService.saveLesson(lessonId)
+      const attendanceItem = template.items.find((i) => i.is_default_attendance)
+
+      await lessonService.updateLesson({
+        lesson_id: lessonId,
+        class_id: lesson.class_id,
+        lesson_date: lesson.lesson_date,
+        template_id: lesson.template_id,
+        status: 'DRAFT',
+        common_data: Object.entries(commonValues).map(([id, value]) => ({
+          template_item_id: Number(id),
+          value,
+        })),
+        student_data: students.map((s) => ({
+          student_id: s.id,
+          items: [
+            ...(attendanceItem
+              ? [
+                  {
+                    template_item_id: attendanceItem.id,
+                    value: s.attendance ?? '',
+                    is_completed: false,
+                  },
+                ]
+              : []),
+            ...s.items.map((item) => ({
+              template_item_id: item.template_item_id,
+              value: item.value,
+              is_completed: item.is_completed ?? false,
+            })),
+          ],
+        })),
+      })
+
       addToast({ variant: 'success', message: '저장됐어요.' })
     } catch {
       addToast({ variant: 'error', message: '저장에 실패했어요.' })
+    }
+  }
+
+  const handleTemplateSelect = (templateId: number) => {
+    setPendingTemplateId(templateId)
+    templateModal.close()
+    confirmModal.open()
+  }
+
+  const handleTemplateChange = async () => {
+    if (!lesson || !pendingTemplateId) return
+    confirmModal.close()
+    try {
+      await lessonService.updateLesson({
+        lesson_id: lessonId,
+        class_id: lesson.class_id,
+        lesson_date: lesson.lesson_date,
+        template_id: pendingTemplateId,
+        status: 'DRAFT',
+        common_data: [],
+        student_data: students.map((s) => ({ student_id: s.id, items: [] })),
+      })
+      refetch()
+    } catch {
+      addToast({ variant: 'error', message: '템플릿 변경에 실패했어요.' })
+    } finally {
+      setPendingTemplateId(null)
     }
   }
 
@@ -68,7 +136,7 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
       {/* 헤더 */}
       <div className={headerStyle}>
         <div className={headerLeftStyle}>
-          <button onClick={() => router.back()} className={backButtonStyle}>
+          <button onClick={() => router.push('/lesson')} className={backButtonStyle}>
             <ArrowLeftIcon width={24} height={24} />
           </button>
           <Text variant="display" as="h1">
@@ -89,7 +157,6 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
             size="sm"
             leftIcon={<SaveIcon width={20} height={20} />}
             onClick={handleSave}
-            disabled={lesson.status === 'SAVED'}
           >
             저장
           </Button>
@@ -103,6 +170,9 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
           <Text variant="bodyMd" color="gray500">
             {template.name}
           </Text>
+          <Button variant="ghost" size="sm" onClick={templateModal.open}>
+            변경
+          </Button>
         </div>
       </div>
 
@@ -121,7 +191,7 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
       {/* 개별 내용 */}
       <div className={sectionStyle}>
         <Text variant="headingMd">개별 내용</Text>
-        <LessonTable students={students} onChange={setStudents} />
+        <LessonTable students={students} templateItems={template.items} onChange={setStudents} />
       </div>
 
       {/* 하단 진행도 */}
@@ -148,6 +218,26 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
           className: lesson.class_name,
           lessonDate: format(new Date(lesson.lesson_date), 'M월 d일(E)', { locale: ko }),
         }}
+      />
+
+      <TemplateSelectModal
+        isOpen={templateModal.isOpen}
+        onClose={templateModal.close}
+        onConfirm={handleTemplateSelect}
+        title="템플릿 변경"
+        confirmLabel="변경"
+      />
+
+      <ConfirmModal
+        isOpen={confirmModal.isOpen}
+        onClose={() => {
+          confirmModal.close()
+          setPendingTemplateId(null)
+        }}
+        onConfirm={handleTemplateChange}
+        title="템플릿을 변경할까요?"
+        descriptions={['템플릿을 변경하면 입력한 내용이 모두 사라져요.']}
+        confirmLabel="변경"
       />
     </div>
   )

--- a/src/app/(main)/lesson/[id]/page.tsx
+++ b/src/app/(main)/lesson/[id]/page.tsx
@@ -7,6 +7,8 @@ import Button from '@/components/common/Button'
 import ArrowLeftIcon from '@/assets/icons/icon-arrow-left.svg'
 import DownloadIcon from '@/assets/icons/icon-download.svg'
 import SaveIcon from '@/assets/icons/icon-save.svg'
+import EditIcon from '@/assets/icons/icon-edit.svg'
+import ChevronDownIcon from '@/assets/icons/icon-chevron-down.svg'
 import MessageIcon from '@/assets/icons/icon-message.svg'
 import LessonTable from './_components/LessonTableSection/LessonTableSection'
 import CommonContent from './_components/CommonContent/CommonContent'
@@ -24,6 +26,7 @@ import {
   backButtonStyle,
   headerLeftStyle,
   headerButtonGroupStyle,
+  templateChipButtonStyle,
 } from './lessonDetail.css'
 import useLessonDetail from '@/hooks/useLessonDetail'
 import useDisclosure from '@/hooks/useDisclosure'
@@ -142,6 +145,15 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
           <Text variant="display" as="h1">
             {format(new Date(lesson.lesson_date), 'M월 d일(E)', { locale: ko })} {lesson.class_name}
           </Text>
+          <Button
+            variant="ghost"
+            size="sm"
+            rightIcon={<ChevronDownIcon width={20} height={20} />}
+            onClick={templateModal.open}
+            className={templateChipButtonStyle}
+          >
+            {template.name}
+          </Button>
         </div>
         <div className={headerButtonGroupStyle}>
           <Button
@@ -159,19 +171,6 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
             onClick={handleSave}
           >
             저장
-          </Button>
-        </div>
-      </div>
-
-      {/* 템플릿 정보 */}
-      <div className={templateSectionStyle}>
-        <div className={templateLabelRowStyle}>
-          <Text variant="headingMd">템플릿</Text>
-          <Text variant="bodyMd" color="gray500">
-            {template.name}
-          </Text>
-          <Button variant="ghost" size="sm" onClick={templateModal.open}>
-            변경
           </Button>
         </div>
       </div>
@@ -224,8 +223,9 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
         isOpen={templateModal.isOpen}
         onClose={templateModal.close}
         onConfirm={handleTemplateSelect}
+        currentTemplateId={lesson.template_id}
         title="템플릿 변경"
-        confirmLabel="변경"
+        confirmLabel="확인"
       />
 
       <ConfirmModal
@@ -238,6 +238,7 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
         title="템플릿을 변경할까요?"
         descriptions={['템플릿을 변경하면 입력한 내용이 모두 사라져요.']}
         confirmLabel="변경"
+        confirmVariant="danger"
       />
     </div>
   )

--- a/src/app/(main)/lesson/_components/LessonCard/LessonCard.tsx
+++ b/src/app/(main)/lesson/_components/LessonCard/LessonCard.tsx
@@ -35,7 +35,7 @@ export default function LessonCard({
     <div className={cardStyle}>
       <div className={chipGroupStyle}>
         <Chip label={academyName} />
-        <Chip variant="active" label={templateName} />
+        {templateName && <Chip variant="active" label={templateName} />}
       </div>
       <Text variant="headingLg">{className}</Text>
       <div className={progressWrapperStyle}>

--- a/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.css.ts
+++ b/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.css.ts
@@ -1,0 +1,52 @@
+import { style } from '@vanilla-extract/css'
+import { recipe } from '@vanilla-extract/recipes'
+import { colors } from '@/styles/tokens/colors'
+import { fontStyles } from '@/styles/tokens/typography'
+
+export const modalContentStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '24px',
+})
+
+export const chipGroupStyle = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '8px',
+})
+
+export const actionsStyle = style({
+  display: 'flex',
+  gap: '8px',
+})
+
+export const chipButtonRecipe = recipe({
+  base: {
+    height: '40px',
+    padding: '0 16px',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    fontSize: fontStyles.bodyMd.fontSize,
+    fontWeight: fontStyles.bodyMd.fontWeight,
+    letterSpacing: '-0.03em',
+    lineHeight: '140%',
+    transition: 'background-color 0.15s, border-color 0.15s, color 0.15s',
+  },
+  variants: {
+    selected: {
+      true: {
+        backgroundColor: colors.primary100,
+        border: `1px solid ${colors.primary500}`,
+        color: colors.primary500,
+      },
+      false: {
+        backgroundColor: colors.white,
+        border: `1px solid ${colors.gray100}`,
+        color: colors.gray500,
+      },
+    },
+  },
+  defaultVariants: {
+    selected: false,
+  },
+})

--- a/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.css.ts
+++ b/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.css.ts
@@ -45,8 +45,64 @@ export const chipButtonRecipe = recipe({
         color: colors.gray500,
       },
     },
+    current: {
+      true: {
+        backgroundColor: colors.gray100,
+        border: `1px solid ${colors.gray200}`,
+        color: colors.gray500,
+        cursor: 'not-allowed',
+      },
+      false: {},
+    },
   },
   defaultVariants: {
     selected: false,
+    current: false,
   },
+})
+
+export const templateCompareStyle = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '12px',
+})
+
+export const templateColStyle = style({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  padding: '16px',
+  backgroundColor: colors.background,
+  borderRadius: '8px',
+  marginBottom: '24px',
+})
+
+export const templateColTitleStyle = style({
+  fontSize: fontStyles.bodyMd.fontSize,
+  fontWeight: fontStyles.bodyMd.fontWeight,
+  letterSpacing: '-0.03em',
+  lineHeight: '140%',
+  color: colors.gray500,
+  textTransform: 'uppercase',
+})
+
+export const itemChipGroupStyle = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '6px',
+})
+
+export const currentTemplateNameStyle = style({
+  height: '40px',
+  padding: '0 12px',
+  borderRadius: '8px',
+  // border: `1px solid ${colors.gray100}`,
+  backgroundColor: colors.white,
+  color: colors.gray700,
+  fontSize: fontStyles.titleSm.fontSize,
+  fontWeight: fontStyles.titleSm.fontWeight,
+  display: 'flex',
+  alignItems: 'center',
+  letterSpacing: '-0.03em',
 })

--- a/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.tsx
+++ b/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.tsx
@@ -15,6 +15,8 @@ import {
   templateColStyle,
   templateColTitleStyle,
   itemChipGroupStyle,
+  chipGroupStyle,
+  chipButtonRecipe,
   currentTemplateNameStyle,
 } from './TemplateSelectModal.css'
 
@@ -79,19 +81,48 @@ export default function TemplateSelectModal({
     .map((t) => ({ label: t.name, value: String(t.id) }))
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} size="md">
+    <Modal isOpen={isOpen} onClose={handleClose} size={currentTemplateId ? 'md' : 'sm'}>
       <div className={modalContentStyle}>
-        <Text variant="headingLg">{title}</Text>
+        <Text variant="headingMd">{title}</Text>
 
-        <div className={templateCompareStyle}>
-          {/* 현재 */}
-          <div className={templateColStyle}>
-            <span className={templateColTitleStyle}>현재</span>
-            {currentDetail ? (
-              <>
-                <div className={currentTemplateNameStyle}>{currentDetail.name}</div>
+        {currentTemplateId ? (
+          // 변경 모드 - 현재 vs 변경 후 비교
+          <div className={templateCompareStyle}>
+            <div className={templateColStyle}>
+              <span className={templateColTitleStyle}>현재</span>
+              {currentDetail ? (
+                <>
+                  <div className={currentTemplateNameStyle}>{currentDetail.name}</div>
+                  <div className={itemChipGroupStyle}>
+                    {currentDetail.items.map((item) => (
+                      <Chip
+                        key={item.id}
+                        label={item.name}
+                        variant={item.is_common ? 'active' : 'default'}
+                      />
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <Text variant="bodyMd" color="gray500">-</Text>
+              )}
+            </div>
+
+            <ArrowRightIcon width={20} height={20} style={{ color: '#9492A9', flexShrink: 0, marginTop: '28px' }} />
+
+            <div className={templateColStyle}>
+              <span className={templateColTitleStyle}>변경 후</span>
+              <Dropdown
+                options={dropdownOptions}
+                value={selectedId ? String(selectedId) : ''}
+                onChange={handleSelect}
+                placeholder="템플릿 선택"
+                fullWidth
+                noBorder
+              />
+              {selectedDetail && (
                 <div className={itemChipGroupStyle}>
-                  {currentDetail.items.map((item) => (
+                  {selectedDetail.items.map((item) => (
                     <Chip
                       key={item.id}
                       label={item.name}
@@ -99,32 +130,23 @@ export default function TemplateSelectModal({
                     />
                   ))}
                 </div>
-              </>
-            ) : (
-              <Text variant="bodyMd" color="gray500">
-                -
-              </Text>
-            )}
+              )}
+            </div>
           </div>
-
-          {/* 화살표 */}
-          <ArrowRightIcon
-            width={20}
-            height={20}
-            style={{ color: '#9492A9', flexShrink: 0, marginTop: '28px' }}
-          />
-
-          {/* 변경 후 */}
-          <div className={templateColStyle}>
-            <span className={templateColTitleStyle}>변경 후</span>
-            <Dropdown
-              options={dropdownOptions}
-              value={selectedId ? String(selectedId) : ''}
-              onChange={handleSelect}
-              placeholder="템플릿 선택"
-              fullWidth
-              noBorder
-            />
+        ) : (
+          // 최초 선택 모드 - 칩 목록
+          <>
+            <div className={chipGroupStyle}>
+              {templates.map((t) => (
+                <button
+                  key={t.id}
+                  className={chipButtonRecipe({ selected: selectedId === t.id })}
+                  onClick={() => handleSelect(String(t.id))}
+                >
+                  {t.name}
+                </button>
+              ))}
+            </div>
             {selectedDetail && (
               <div className={itemChipGroupStyle}>
                 {selectedDetail.items.map((item) => (
@@ -136,16 +158,16 @@ export default function TemplateSelectModal({
                 ))}
               </div>
             )}
-          </div>
-        </div>
+          </>
+        )}
 
         <div className={actionsStyle}>
-          <Button variant="ghost" size="lg" fullWidth onClick={handleClose}>
+          <Button variant="ghost" size="md" fullWidth onClick={handleClose}>
             취소
           </Button>
           <Button
             variant="primary"
-            size="lg"
+            size="md"
             fullWidth
             onClick={handleConfirm}
             disabled={!selectedId || isLoading}

--- a/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.tsx
+++ b/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Modal from '@/components/common/Modal'
+import Text from '@/components/common/Text'
+import Button from '@/components/common/Button'
+import { templateService, type Template } from '@/services/template'
+import { modalContentStyle, chipGroupStyle, actionsStyle, chipButtonRecipe } from './TemplateSelectModal.css'
+
+interface TemplateSelectModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: (templateId: number) => void | Promise<void>
+  title?: string
+  confirmLabel?: string
+}
+
+export default function TemplateSelectModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  title = '템플릿 선택',
+  confirmLabel = '확인',
+}: TemplateSelectModalProps) {
+  const [templates, setTemplates] = useState<Template[]>([])
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) return
+    templateService.getTemplates().then(setTemplates)
+  }, [isOpen])
+
+  const handleConfirm = async () => {
+    if (!selectedId) return
+    setIsLoading(true)
+    try {
+      await onConfirm(selectedId)
+    } finally {
+      setIsLoading(false)
+      setSelectedId(null)
+    }
+  }
+
+  const handleClose = () => {
+    setSelectedId(null)
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} size="sm">
+      <div className={modalContentStyle}>
+        <Text variant="headingMd">{title}</Text>
+        <div className={chipGroupStyle}>
+          {templates.map((t) => (
+            <button
+              key={t.id}
+              className={chipButtonRecipe({ selected: selectedId === t.id })}
+              onClick={() => setSelectedId(t.id)}
+            >
+              {t.name}
+            </button>
+          ))}
+        </div>
+        <div className={actionsStyle}>
+          <Button variant="ghost" size="md" fullWidth onClick={handleClose}>
+            취소
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            fullWidth
+            onClick={handleConfirm}
+            disabled={!selectedId || isLoading}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.tsx
+++ b/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.tsx
@@ -4,13 +4,25 @@ import { useEffect, useState } from 'react'
 import Modal from '@/components/common/Modal'
 import Text from '@/components/common/Text'
 import Button from '@/components/common/Button'
-import { templateService, type Template } from '@/services/template'
-import { modalContentStyle, chipGroupStyle, actionsStyle, chipButtonRecipe } from './TemplateSelectModal.css'
+import Chip from '@/components/common/Chip'
+import Dropdown from '@/components/common/Dropdown'
+import ArrowRightIcon from '@/assets/icons/icon-chevron-right.svg'
+import { templateService, type Template, type TemplateDetail } from '@/services/template'
+import {
+  modalContentStyle,
+  actionsStyle,
+  templateCompareStyle,
+  templateColStyle,
+  templateColTitleStyle,
+  itemChipGroupStyle,
+  currentTemplateNameStyle,
+} from './TemplateSelectModal.css'
 
 interface TemplateSelectModalProps {
   isOpen: boolean
   onClose: () => void
   onConfirm: (templateId: number) => void | Promise<void>
+  currentTemplateId?: number
   title?: string
   confirmLabel?: string
 }
@@ -19,17 +31,30 @@ export default function TemplateSelectModal({
   isOpen,
   onClose,
   onConfirm,
+  currentTemplateId,
   title = '템플릿 선택',
   confirmLabel = '확인',
 }: TemplateSelectModalProps) {
   const [templates, setTemplates] = useState<Template[]>([])
   const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [currentDetail, setCurrentDetail] = useState<TemplateDetail | null>(null)
+  const [selectedDetail, setSelectedDetail] = useState<TemplateDetail | null>(null)
   const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
     if (!isOpen) return
     templateService.getTemplates().then(setTemplates)
-  }, [isOpen])
+    if (currentTemplateId) {
+      templateService.getTemplate(currentTemplateId).then(setCurrentDetail)
+    }
+  }, [isOpen, currentTemplateId])
+
+  const handleSelect = async (value: string) => {
+    const id = Number(value)
+    setSelectedId(id)
+    const detail = await templateService.getTemplate(id)
+    setSelectedDetail(detail)
+  }
 
   const handleConfirm = async () => {
     if (!selectedId) return
@@ -39,36 +64,88 @@ export default function TemplateSelectModal({
     } finally {
       setIsLoading(false)
       setSelectedId(null)
+      setSelectedDetail(null)
     }
   }
 
   const handleClose = () => {
     setSelectedId(null)
+    setSelectedDetail(null)
     onClose()
   }
 
+  const dropdownOptions = templates
+    .filter((t) => t.id !== currentTemplateId)
+    .map((t) => ({ label: t.name, value: String(t.id) }))
+
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} size="sm">
+    <Modal isOpen={isOpen} onClose={handleClose} size="md">
       <div className={modalContentStyle}>
-        <Text variant="headingMd">{title}</Text>
-        <div className={chipGroupStyle}>
-          {templates.map((t) => (
-            <button
-              key={t.id}
-              className={chipButtonRecipe({ selected: selectedId === t.id })}
-              onClick={() => setSelectedId(t.id)}
-            >
-              {t.name}
-            </button>
-          ))}
+        <Text variant="headingLg">{title}</Text>
+
+        <div className={templateCompareStyle}>
+          {/* 현재 */}
+          <div className={templateColStyle}>
+            <span className={templateColTitleStyle}>현재</span>
+            {currentDetail ? (
+              <>
+                <div className={currentTemplateNameStyle}>{currentDetail.name}</div>
+                <div className={itemChipGroupStyle}>
+                  {currentDetail.items.map((item) => (
+                    <Chip
+                      key={item.id}
+                      label={item.name}
+                      variant={item.is_common ? 'active' : 'default'}
+                    />
+                  ))}
+                </div>
+              </>
+            ) : (
+              <Text variant="bodyMd" color="gray500">
+                -
+              </Text>
+            )}
+          </div>
+
+          {/* 화살표 */}
+          <ArrowRightIcon
+            width={20}
+            height={20}
+            style={{ color: '#9492A9', flexShrink: 0, marginTop: '28px' }}
+          />
+
+          {/* 변경 후 */}
+          <div className={templateColStyle}>
+            <span className={templateColTitleStyle}>변경 후</span>
+            <Dropdown
+              options={dropdownOptions}
+              value={selectedId ? String(selectedId) : ''}
+              onChange={handleSelect}
+              placeholder="템플릿 선택"
+              fullWidth
+              noBorder
+            />
+            {selectedDetail && (
+              <div className={itemChipGroupStyle}>
+                {selectedDetail.items.map((item) => (
+                  <Chip
+                    key={item.id}
+                    label={item.name}
+                    variant={item.is_common ? 'active' : 'default'}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
         </div>
+
         <div className={actionsStyle}>
-          <Button variant="ghost" size="md" fullWidth onClick={handleClose}>
+          <Button variant="ghost" size="lg" fullWidth onClick={handleClose}>
             취소
           </Button>
           <Button
             variant="primary"
-            size="md"
+            size="lg"
             fullWidth
             onClick={handleConfirm}
             disabled={!selectedId || isLoading}

--- a/src/app/(main)/lesson/new/page.tsx
+++ b/src/app/(main)/lesson/new/page.tsx
@@ -1,117 +1,60 @@
 'use client'
 
-import { use, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Suspense } from 'react'
-import Text from '@/components/common/Text'
-import Button from '@/components/common/Button'
-import ArrowLeftIcon from '@/assets/icons/icon-arrow-left.svg'
-import { templateService } from '@/services/template'
 import { lessonService } from '@/services/lesson'
+import { classService } from '@/services/class'
 import { useToastStore } from '@/stores/toastStore'
-import type { Template } from '@/services/template'
-import {
-  pageStyle,
-  headerStyle,
-  backButtonStyle,
-  headerLeftStyle,
-  templateSectionStyle,
-  templateLabelRowStyle,
-  templateChipGroupStyle,
-  templateChipRecipe,
-} from '../[id]/lessonDetail.css'
+import TemplateSelectModal from '../_components/TemplateSelectModal/TemplateSelectModal'
 
 function LessonNewContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const classId = Number(searchParams.get('class_id'))
   const date = searchParams.get('date') ?? ''
+  const isAdhoc = searchParams.get('is_adhoc') !== 'false'
   const addToast = useToastStore((s) => s.addToast)
 
-  const [templates, setTemplates] = useState<Template[]>([])
-  const [selectedTemplateId, setSelectedTemplateId] = useState<number | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
-
-  useEffect(() => {
-    templateService.getTemplates().then((res) => {
-      setTemplates(res)
-      if (res.length > 0) setSelectedTemplateId(res[0].id)  // 첫 번째 자동 선택
-    })
-  }, [])
-
-  const handleCreate = async () => {
-    if (!selectedTemplateId) return
-    setIsLoading(true)
+  const handleConfirm = async (templateId: number) => {
     try {
-      const lesson = await lessonService.createLesson({
-        class_id: classId,
-        template_id: selectedTemplateId,
-        lesson_date: date,
-        is_adhoc: true,
-        status: 'DRAFT',
-        common_data: [],
-        student_data: [],
-      })
-      router.push(`/lesson/${lesson.id}`)
-    } catch {
-      addToast({ variant: 'error', message: '수업 생성에 실패했어요.' })
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  const handleSelectTemplate = async (templateId: number) => {
-    setSelectedTemplateId(templateId)
-    setIsLoading(true)
-    try {
+      const classStudents = await classService.getClassStudents(classId, date)
       const lesson = await lessonService.createLesson({
         class_id: classId,
         template_id: templateId,
         lesson_date: date,
-        is_adhoc: true,
+        is_adhoc: isAdhoc,
         status: 'DRAFT',
         common_data: [],
-        student_data: [],
+        student_data: classStudents.map((s) => ({ student_id: s.id, items: [] })),
       })
       router.push(`/lesson/${lesson.id}`)
-    } catch {
+    } catch (err: any) {
+      if (err?.response?.status === 409) {
+        const conflictId = err?.response?.data?.data?.id ?? err?.response?.data?.data?.lesson_record_id
+        if (conflictId) {
+          router.push(`/lesson/${conflictId}`)
+          return
+        }
+        const res = await lessonService.getLessons(date)
+        const existing = res.data.find((l) => l.class_id === classId)
+        const existingId = existing?.lesson_record_id ?? existing?.id
+        if (existingId) {
+          router.push(`/lesson/${existingId}`)
+          return
+        }
+      }
       addToast({ variant: 'error', message: '수업 생성에 실패했어요.' })
-    } finally {
-      setIsLoading(false)
     }
   }
 
   return (
-    <div className={pageStyle}>
-      <div className={headerStyle}>
-        <div className={headerLeftStyle}>
-          <button onClick={() => router.back()} className={backButtonStyle}>
-            <ArrowLeftIcon width={24} height={24} />
-          </button>
-          <Text variant="display" as="h1">수업 추가</Text>
-        </div>
-      </div>
-
-      <div className={templateSectionStyle}>
-        <div className={templateLabelRowStyle}>
-          <Text variant="headingMd">템플릿</Text>
-          <Text variant="bodyMd" color="gray500">
-            수업에 적용할 템플릿을 선택해주세요
-          </Text>
-        </div>
-        <div className={templateChipGroupStyle}>
-          {templates.map((t) => (
-            <button
-              key={t.id}
-              className={templateChipRecipe({ selected: selectedTemplateId === t.id })}
-              onClick={() => handleSelectTemplate(t.id)}
-            >
-              {t.name}
-            </button>
-          ))}
-        </div>
-      </div>
-    </div>
+    <TemplateSelectModal
+      isOpen={true}
+      onClose={() => router.push('/lesson')}
+      onConfirm={handleConfirm}
+      title="템플릿 선택"
+      confirmLabel="수업 입력하기"
+    />
   )
 }
 

--- a/src/app/(main)/lesson/page.tsx
+++ b/src/app/(main)/lesson/page.tsx
@@ -99,8 +99,8 @@ export default function LessonPage() {
             templateName={lesson.template_name}
             className={lesson.class_name}
             progress={lesson.progress_rate}
-            totalStudents={0}
-            inputCount={0}
+            totalStudents={lesson.total_students}
+            inputCount={Math.round((lesson.total_students * lesson.progress_rate) / 100)}
             isDone={lesson.status === 'SAVED'}
             onClick={() => router.push(`/lesson/${lesson.lesson_record_id}`)}
           />

--- a/src/app/(main)/lesson/page.tsx
+++ b/src/app/(main)/lesson/page.tsx
@@ -92,19 +92,30 @@ export default function LessonPage() {
         <Text variant="headingMd">{selectedLabel}</Text>
       </div>
       <div className={lessonGridStyle}>
-        {lessons.map((lesson) => (
-          <LessonCard
-            key={lesson.lesson_record_id}
-            academyName={lesson.academy_name}
-            templateName={lesson.template_name}
-            className={lesson.class_name}
-            progress={lesson.progress_rate}
-            totalStudents={lesson.total_students}
-            inputCount={Math.round((lesson.total_students * lesson.progress_rate) / 100)}
-            isDone={lesson.status === 'SAVED'}
-            onClick={() => router.push(`/lesson/${lesson.lesson_record_id}`)}
-          />
-        ))}
+        {lessons.map((lesson) => {
+          const recordId = lesson.lesson_record_id ?? lesson.id ?? null
+          return (
+            <LessonCard
+              key={recordId ?? lesson.class_id}
+              academyName={lesson.academy_name}
+              templateName={lesson.template_name}
+              className={lesson.class_name}
+              progress={lesson.progress_rate}
+              totalStudents={lesson.total_students}
+              inputCount={Math.round((lesson.total_students * lesson.progress_rate) / 100)}
+              isDone={recordId !== null}
+              onClick={() => {
+                if (recordId) {
+                  router.push(`/lesson/${recordId}`)
+                } else {
+                  router.push(
+                    `/lesson/new?class_id=${lesson.class_id}&date=${format(selectedDate, 'yyyy-MM-dd')}&is_adhoc=false`
+                  )
+                }
+              }}
+            />
+          )
+        })}
         <AddCard
           icon={<PlusCircleIcon width={36} height={36} />}
           label="다른 수업 추가"
@@ -117,7 +128,7 @@ export default function LessonPage() {
           onClose={() => setIsAddLessonOpen(false)}
           onConfirm={(classId) => {
             router.push(
-              `/lesson/new?class_id=${classId}&date=${format(selectedDate, 'yyyy-MM-dd')}`
+              `/lesson/new?class_id=${classId}&date=${format(selectedDate, 'yyyy-MM-dd')}&is_adhoc=true`
             )
           }}
           selectedDate={selectedDate}

--- a/src/app/(main)/management/_components/ClassFormModal/ClassFormModal.tsx
+++ b/src/app/(main)/management/_components/ClassFormModal/ClassFormModal.tsx
@@ -21,7 +21,7 @@ const DAYS = [
   { label: '목', value: 4 },
   { label: '금', value: 5 },
   { label: '토', value: 6 },
-  { label: '일', value: 7 },
+  { label: '일', value: 0 },
 ]
 
 interface ClassFormData {

--- a/src/components/common/Dropdown/Dropdown.css.ts
+++ b/src/components/common/Dropdown/Dropdown.css.ts
@@ -14,6 +14,11 @@ export const containerStyle = style({
   display: 'inline-block',
 })
 
+export const containerFullWidthStyle = style({
+  display: 'block',
+  width: '100%',
+})
+
 export const triggerStyle = style({
   display: 'flex',
   alignItems: 'center',
@@ -33,13 +38,28 @@ export const triggerStyle = style({
   },
 })
 
+export const triggerNoBorderStyle = style({
+  border: 'none',
+  backgroundColor: colors.white,
+  selectors: {
+    '&:hover': {
+      backgroundColor: colors.gray50,
+    },
+  },
+})
+
+export const triggerFullWidthStyle = style({
+  width: '100%',
+  justifyContent: 'space-between',
+})
+
 export const triggerActiveStyle = style({
   color: colors.primary500,
 })
 
 export const menuStyle = style({
   position: 'absolute',
-  top: 'calc(100% + 4px)',
+  top: 'calc(100% + 8px)',
   left: 0,
   backgroundColor: colors.white,
   border: `1px solid ${colors.gray200}`,
@@ -48,6 +68,11 @@ export const menuStyle = style({
   minWidth: '100%',
   overflow: 'hidden',
   padding: '8px 0',
+})
+
+export const menuNoBorderStyle = style({
+  border: 'none',
+  boxShadow: `0 4px 16px rgba(0, 0, 0, 0.08)`,
 })
 
 export const menuLabelStyle = style({

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -12,6 +12,10 @@ import {
   optionSelectedStyle,
   chevronStyle,
   chevronOpenStyle,
+  triggerNoBorderStyle,
+  triggerFullWidthStyle,
+  containerFullWidthStyle,
+  menuNoBorderStyle,
 } from './Dropdown.css'
 
 interface DropdownOption {
@@ -26,6 +30,8 @@ interface DropdownProps {
   placeholder?: string
   menuLabel?: string
   triggerClassName?: string
+  noBorder?: boolean
+  fullWidth?: boolean
 }
 
 export default function Dropdown({
@@ -35,6 +41,8 @@ export default function Dropdown({
   placeholder = '선택',
   menuLabel,
   triggerClassName,
+  noBorder = false,
+  fullWidth = false,
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -53,9 +61,20 @@ export default function Dropdown({
   }, [])
 
   return (
-    <div className={containerStyle} ref={containerRef}>
+    <div
+      className={[containerStyle, fullWidth ? containerFullWidthStyle : ''].join(' ').trim()}
+      ref={containerRef}
+    >
       <button
-        className={[triggerStyle, isSelected ? triggerActiveStyle : '', triggerClassName ?? ''].join(' ').trim()}
+        className={[
+          triggerStyle,
+          noBorder ? triggerNoBorderStyle : '',
+          fullWidth ? triggerFullWidthStyle : '',
+          isSelected ? triggerActiveStyle : '',
+          triggerClassName ?? '',
+        ]
+          .join(' ')
+          .trim()}
         onClick={() => setIsOpen((prev) => !prev)}
       >
         {selectedOption ? selectedOption.label : placeholder}
@@ -66,7 +85,7 @@ export default function Dropdown({
         />
       </button>
       {isOpen && (
-        <div className={menuStyle}>
+        <div className={[menuStyle, noBorder ? menuNoBorderStyle : ''].join(' ').trim()}>
           {menuLabel && <div className={menuLabelStyle}>{menuLabel}</div>}
           {options.map((opt) => (
             <div

--- a/src/hooks/useLessonDetail.ts
+++ b/src/hooks/useLessonDetail.ts
@@ -15,84 +15,87 @@ export default function useLessonDetail(lessonId: number) {
   const [students, setStudents] = useState<LessonStudent[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [refreshKey, setRefreshKey] = useState(0)
+  const [error, setError] = useState<'TEMPLATE_NOT_FOUND' | null>(null)
   const messagePreview = useDisclosure()
 
-  const refetch = () => setRefreshKey((k) => k + 1)
+  const refetch = () => {
+    setError(null)
+    setRefreshKey((k) => k + 1)
+  }
 
   useEffect(() => {
     if (!lessonId) return
     setIsLoading(true)
     let cancelled = false
 
-    lessonService.getLesson(lessonId).then(async (data) => {
-      if (cancelled) return
-      setLesson(data)
+    lessonService
+      .getLesson(lessonId)
+      .then(async (data) => {
+        if (cancelled) return
+        setLesson(data)
 
-      // common_data 초기값 세팅
-      const values: Record<number, string> = {}
-      data.common_data.forEach((item) => {
-        values[item.template_item_id] = item.value
-      })
-      setCommonValues(values)
+        const values: Record<number, string> = {}
+        data.common_data.forEach((item) => {
+          values[item.template_item_id] = item.value
+        })
+        setCommonValues(values)
 
-      // 템플릿 상세 조회
-      const tmpl = await templateService.getTemplate(data.template_id)
-      setTemplate(tmpl)
+        try {
+          const tmpl = await templateService.getTemplate(data.template_id)
+          setTemplate(tmpl)
 
-      // 출결 아이템
-      const attendanceItem = tmpl.items.find((i) => i.is_default_attendance)
+          const attendanceItem = tmpl.items.find((i) => i.is_default_attendance)
+          const individualItems = tmpl.items.filter((i) => !i.is_common && !i.is_default_attendance)
+          const classStudents = await classService.getClassStudents(data.class_id, data.lesson_date)
+          const studentDataMap = new Map(data.student_data.map((sd) => [sd.student_id, sd.items]))
 
-      // 동적 아이템 목록 (개별, 출결 제외)
-      const individualItems = tmpl.items.filter((i) => !i.is_common && !i.is_default_attendance)
+          const validStudentIds =
+            data.student_data.length > 0
+              ? new Set(data.student_data.map((sd) => sd.student_id))
+              : null
+          const baseStudents = validStudentIds
+            ? classStudents.filter((s) => validStudentIds.has(s.id))
+            : classStudents
 
-      // 반 소속 학생 목록 조회 (레슨 날짜 기준)
-      const classStudents = await classService.getClassStudents(data.class_id, data.lesson_date)
+          const initialized: LessonStudent[] = baseStudents.map((s) => {
+            const existingItems = studentDataMap.get(s.id) ?? []
+            const attendanceRaw = attendanceItem
+              ? (existingItems.find((ei) => ei.template_item_id === attendanceItem.id)?.value ?? null)
+              : null
+            const attendance: LessonStudent['attendance'] =
+              attendanceRaw === '출석' || attendanceRaw === '지각' || attendanceRaw === '결석'
+                ? attendanceRaw
+                : null
 
-      // student_data를 Map으로 변환
-      const studentDataMap = new Map(
-        data.student_data.map((sd) => [sd.student_id, sd.items])
-      )
-
-      // 레슨에 기존 student_data가 있으면 해당 학생만 사용
-      // (레슨 날짜 기준 반 소속 검증 에러 방지)
-      const validStudentIds = data.student_data.length > 0
-        ? new Set(data.student_data.map((sd) => sd.student_id))
-        : null
-      const baseStudents = validStudentIds
-        ? classStudents.filter((s) => validStudentIds.has(s.id))
-        : classStudents
-
-      // LessonStudent 초기화
-      const initialized: LessonStudent[] = baseStudents.map((s) => {
-        const existingItems = studentDataMap.get(s.id) ?? []
-
-        // 출결 복원
-        const attendanceRaw = attendanceItem
-          ? existingItems.find((ei) => ei.template_item_id === attendanceItem.id)?.value ?? null
-          : null
-        const attendance: LessonStudent['attendance'] =
-          attendanceRaw === '출석' || attendanceRaw === '지각' || attendanceRaw === '결석'
-            ? attendanceRaw
-            : null
-
-        return {
-          id: s.id,
-          name: s.name,
-          attendance,
-          items: individualItems.map((item) => {
-            const existing = existingItems.find((ei) => ei.template_item_id === item.id)
             return {
-              template_item_id: item.id,
-              value: existing?.value ?? '',
-              is_completed: existing?.is_completed ?? null,
+              id: s.id,
+              name: s.name,
+              attendance,
+              items: individualItems.map((item) => {
+                const existing = existingItems.find((ei) => ei.template_item_id === item.id)
+                return {
+                  template_item_id: item.id,
+                  value: existing?.value ?? '',
+                  is_completed: existing?.is_completed ?? null,
+                }
+              }),
             }
-          }),
+          })
+          setStudents(initialized)
+        } catch (err: any) {
+          if (cancelled) return
+          if (err?.response?.data?.error?.code === 'TEMPLATE_NOT_FOUND') {
+            setError('TEMPLATE_NOT_FOUND')
+          }
         }
       })
-      setStudents(initialized)
-    }).finally(() => { if (!cancelled) setIsLoading(false) })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
 
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [lessonId, refreshKey])
 
   const inputCount = students.filter((s) => s.attendance !== null).length
@@ -101,7 +104,9 @@ export default function useLessonDetail(lessonId: number) {
     if (!lesson || !template) return
     exportLessonExcel({
       title: `${format(new Date(lesson.lesson_date), 'M월 d일(E)', { locale: ko })} ${lesson.class_name} 수업 결과`,
-      commonItems: template.items.filter((i) => i.is_common).map((i) => ({ id: i.id, label: i.name })),
+      commonItems: template.items
+        .filter((i) => i.is_common)
+        .map((i) => ({ id: i.id, label: i.name })),
       commonValues,
       students,
       context: {
@@ -117,6 +122,7 @@ export default function useLessonDetail(lessonId: number) {
     lesson,
     setLesson,
     template,
+    error,
     commonValues,
     setCommonValues,
     students,

--- a/src/hooks/useLessonDetail.ts
+++ b/src/hooks/useLessonDetail.ts
@@ -2,7 +2,10 @@ import { useState, useEffect } from 'react'
 import type { LessonStudent } from '@/types/lessonStudent'
 import { lessonService, type LessonDetail } from '@/services/lesson'
 import { templateService, type TemplateDetail } from '@/services/template'
+import { classService } from '@/services/class'
 import { exportLessonExcel } from '@/lib/exportExcel'
+import { format } from 'date-fns'
+import { ko } from 'date-fns/locale'
 import useDisclosure from './useDisclosure'
 
 export default function useLessonDetail(lessonId: number) {
@@ -11,53 +14,108 @@ export default function useLessonDetail(lessonId: number) {
   const [commonValues, setCommonValues] = useState<Record<number, string>>({})
   const [students, setStudents] = useState<LessonStudent[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [refreshKey, setRefreshKey] = useState(0)
   const messagePreview = useDisclosure()
+
+  const refetch = () => setRefreshKey((k) => k + 1)
 
   useEffect(() => {
     if (!lessonId) return
     setIsLoading(true)
-    lessonService
-      .getLesson(lessonId)
-      .then(async (data) => {
-        setLesson(data)
-        // common_data 초기값 세팅
-        const values: Record<number, string> = {}
-        data.common_data.forEach((item) => {
-          values[item.template_item_id] = item.value
-        })
-        setCommonValues(values)
-        // 템플릿 상세 조회
-        const tmpl = await templateService.getTemplate(data.template_id)
-        setTemplate(tmpl)
-      })
-      .finally(() => setIsLoading(false))
-  }, [lessonId])
+    let cancelled = false
 
-  const inputCount = students.filter((s) =>
-    s.attendance !== null &&
-    s.homework !== null &&
-    s.answerNote !== null &&
-    s.score !== ''
-  ).length
+    lessonService.getLesson(lessonId).then(async (data) => {
+      if (cancelled) return
+      setLesson(data)
+
+      // common_data 초기값 세팅
+      const values: Record<number, string> = {}
+      data.common_data.forEach((item) => {
+        values[item.template_item_id] = item.value
+      })
+      setCommonValues(values)
+
+      // 템플릿 상세 조회
+      const tmpl = await templateService.getTemplate(data.template_id)
+      setTemplate(tmpl)
+
+      // 출결 아이템
+      const attendanceItem = tmpl.items.find((i) => i.is_default_attendance)
+
+      // 동적 아이템 목록 (개별, 출결 제외)
+      const individualItems = tmpl.items.filter((i) => !i.is_common && !i.is_default_attendance)
+
+      // 반 소속 학생 목록 조회 (레슨 날짜 기준)
+      const classStudents = await classService.getClassStudents(data.class_id, data.lesson_date)
+
+      // student_data를 Map으로 변환
+      const studentDataMap = new Map(
+        data.student_data.map((sd) => [sd.student_id, sd.items])
+      )
+
+      // 레슨에 기존 student_data가 있으면 해당 학생만 사용
+      // (레슨 날짜 기준 반 소속 검증 에러 방지)
+      const validStudentIds = data.student_data.length > 0
+        ? new Set(data.student_data.map((sd) => sd.student_id))
+        : null
+      const baseStudents = validStudentIds
+        ? classStudents.filter((s) => validStudentIds.has(s.id))
+        : classStudents
+
+      // LessonStudent 초기화
+      const initialized: LessonStudent[] = baseStudents.map((s) => {
+        const existingItems = studentDataMap.get(s.id) ?? []
+
+        // 출결 복원
+        const attendanceRaw = attendanceItem
+          ? existingItems.find((ei) => ei.template_item_id === attendanceItem.id)?.value ?? null
+          : null
+        const attendance: LessonStudent['attendance'] =
+          attendanceRaw === '출석' || attendanceRaw === '지각' || attendanceRaw === '결석'
+            ? attendanceRaw
+            : null
+
+        return {
+          id: s.id,
+          name: s.name,
+          attendance,
+          items: individualItems.map((item) => {
+            const existing = existingItems.find((ei) => ei.template_item_id === item.id)
+            return {
+              template_item_id: item.id,
+              value: existing?.value ?? '',
+              is_completed: existing?.is_completed ?? null,
+            }
+          }),
+        }
+      })
+      setStudents(initialized)
+    }).finally(() => { if (!cancelled) setIsLoading(false) })
+
+    return () => { cancelled = true }
+  }, [lessonId, refreshKey])
+
+  const inputCount = students.filter((s) => s.attendance !== null).length
 
   const handleExcelDownload = () => {
     if (!lesson || !template) return
     exportLessonExcel({
-      title: `${lesson.lesson_date} 수업 결과`,
+      title: `${format(new Date(lesson.lesson_date), 'M월 d일(E)', { locale: ko })} ${lesson.class_name} 수업 결과`,
       commonItems: template.items.filter((i) => i.is_common).map((i) => ({ id: i.id, label: i.name })),
       commonValues,
       students,
       context: {
-        academyName: '',
+        academyName: lesson.academy_name,
         teacherName: '',
-        className: '',
-        lessonDate: lesson.lesson_date,
+        className: lesson.class_name,
+        lessonDate: format(new Date(lesson.lesson_date), 'M월 d일(E)', { locale: ko }),
       },
     })
   }
 
   return {
     lesson,
+    setLesson,
     template,
     commonValues,
     setCommonValues,
@@ -67,5 +125,6 @@ export default function useLessonDetail(lessonId: number) {
     inputCount,
     isLoading,
     handleExcelDownload,
+    refetch,
   }
 }

--- a/src/services/class.ts
+++ b/src/services/class.ts
@@ -71,9 +71,11 @@ export const classService = {
   },
 
   // 소속 학생 목록 조회
-  async getClassStudents(id: number): Promise<Student[]> {
-    const { data } = await axiosInstance.get(`/classes/${id}/students`)
-    return data.data
+  async getClassStudents(id: number, date?: string): Promise<Student[]> {
+    const { data } = await axiosInstance.get(`/classes/${id}/students`, {
+      params: date ? { date } : undefined,
+    })
+    return data.data.data
   },
 
   // 학생 추가

--- a/src/services/lesson.ts
+++ b/src/services/lesson.ts
@@ -1,7 +1,8 @@
 import axiosInstance from '@/lib/api/axiosInstance'
 
 export interface LessonSummary {
-  lesson_record_id: number
+  id?: number | null
+  lesson_record_id: number | null
   class_id: number
   class_name: string
   academy_name: string
@@ -59,6 +60,9 @@ export interface CreateLessonDto {
 }
 
 export interface UpdateLessonDto {
+  lesson_id: number
+  class_id: number
+  lesson_date: string
   template_id?: number
   status?: 'DRAFT' | 'SAVED'
   common_data: CommonDataItem[]
@@ -76,13 +80,13 @@ export const lessonService = {
     return data.data
   },
 
-  async createLesson(dto: CreateLessonDto): Promise<any> {
+  async createLesson(dto: CreateLessonDto): Promise<LessonDetail> {
     const { data } = await axiosInstance.post('/lessons', dto)
     return data.data
   },
 
-  async updateLesson(id: number, dto: UpdateLessonDto): Promise<any> {
-    const { data } = await axiosInstance.put(`/lessons/${id}`, dto)
+  async updateLesson(dto: UpdateLessonDto): Promise<LessonDetail> {
+    const { data } = await axiosInstance.post('/lessons', dto)
     return data.data
   },
 

--- a/src/services/lesson.ts
+++ b/src/services/lesson.ts
@@ -8,6 +8,7 @@ export interface LessonSummary {
   template_id: number
   template_name: string
   progress_rate: number
+  total_students: number
   status: 'DRAFT' | 'SAVED'
   is_adhoc: boolean
 }

--- a/src/types/lessonStudent.ts
+++ b/src/types/lessonStudent.ts
@@ -1,12 +1,15 @@
 export type Attendance = '출석' | '지각' | '결석' | null
 export type CompletionStatus = '완료' | '미완료' | null
 
+export interface LessonStudentItem {
+  template_item_id: number
+  value: string
+  is_completed?: boolean | null
+}
+
 export interface LessonStudent {
   id: number
   name: string
-  attendance: Attendance
-  homework: CompletionStatus
-  answerNote: CompletionStatus
-  score: string
-  memo: string
+  attendance: Attendance  // 고정
+  items: LessonStudentItem[]  // 동적 아이템
 }


### PR DESCRIPTION
## 이슈 넘버

- close #49 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- `total_students` 필드 연동
- 수업 입력 플로우 UX 개선 (템플릿 선택 모달 분리, 변경 시 경고)
- 문자 미리보기 `GET /api/v1/lessons/{id}/preview` 연동
- 템플릿 삭제 시 예외 처리
- 템플릿 변경 모달 UI 개선 (현재 vs 변경 후 비교)

## 알려진 이슈
- 동적 칼럼 미구현 — `is_default_attendance` 필드 이슈로 동적 칼럼 구현 불가, 백엔드에 `item_type: ATTENDANCE` 추가 요청 중