### PR TITLE
fix: 완료형 항목 미선택 시 저장 후 재진입하면 미완료로 표시되는 버그 수정

### DIFF
--- a/src/app/(main)/lesson/[id]/page.tsx
+++ b/src/app/(main)/lesson/[id]/page.tsx
@@ -86,7 +86,8 @@ export default function LessonDetailPage({ params }: { params: Promise<{ id: str
             ...s.items.map((item) => ({
               template_item_id: item.template_item_id,
               value: item.value,
-              is_completed: item.is_completed ?? false,
+              // Fix #2: null(미선택)은 null 그대로 전송, ?? false 제거
+              is_completed: item.is_completed ?? undefined,
             })),
           ],
         })),

--- a/src/hooks/useLessonDetail.ts
+++ b/src/hooks/useLessonDetail.ts
@@ -79,7 +79,12 @@ export default function useLessonDetail(lessonId: number) {
                 return {
                   template_item_id: item.id,
                   value: existing?.value ?? '',
-                  is_completed: existing?.is_completed ?? null,
+                  // Fix #2: boolean 타입일 때만 저장값 사용, null/undefined면 null로 초기화
+                  // ?? 연산자는 false를 유효값으로 통과시키지만, 서버 응답에서
+                  // is_completed 필드 자체가 누락되거나 null로 오는 경우를 명시적으로 처리
+                  is_completed: typeof existing?.is_completed === 'boolean'
+                    ? existing.is_completed
+                    : null,
                 }
               }),
             }


### PR DESCRIPTION
## 이슈 넘버

- close #57
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
- 문제
완료형(COMPLETE) 항목을 선택하지 않은 상태(null)로 저장하면, 재진입 시 미완료(false)로 표시됨
- 원인
LessonDetailPage.tsx의 handleSave에서 is_completed: item.is_completed ?? false 처리로 인해 미선택(null)이 미완료(false)로 변환되어 서버에 저장됨
- 수정
null일 때 undefined로 처리해 JSON 직렬화 시 필드를 생략. 서버가 null 상태를 유지하도록 수정