### PR TITLE
fix: 엑셀 다운로드 더미 데이터 제거 및 실제 데이터 연동

### DIFF
--- a/src/hooks/useLessonDetail.ts
+++ b/src/hooks/useLessonDetail.ts
@@ -79,12 +79,11 @@ export default function useLessonDetail(lessonId: number) {
                 return {
                   template_item_id: item.id,
                   value: existing?.value ?? '',
-                  // Fix #2: boolean 타입일 때만 저장값 사용, null/undefined면 null로 초기화
+                  // fix: boolean 타입일 때만 저장값 사용, null/undefined면 null로 초기화
                   // ?? 연산자는 false를 유효값으로 통과시키지만, 서버 응답에서
                   // is_completed 필드 자체가 누락되거나 null로 오는 경우를 명시적으로 처리
-                  is_completed: typeof existing?.is_completed === 'boolean'
-                    ? existing.is_completed
-                    : null,
+                  is_completed:
+                    typeof existing?.is_completed === 'boolean' ? existing.is_completed : null,
                 }
               }),
             }
@@ -116,6 +115,10 @@ export default function useLessonDetail(lessonId: number) {
 
   const handleExcelDownload = () => {
     if (!lesson || !template) return
+    const individualItems = template.items
+      .filter((i) => !i.is_common && i.item_type !== 'ATTENDANCE')
+      .map((i) => ({ id: i.id, label: i.name }))
+
     exportLessonExcel({
       title: `${format(new Date(lesson.lesson_date), 'M월 d일(E)', { locale: ko })} ${lesson.class_name} 수업 결과`,
       commonItems: template.items
@@ -123,6 +126,7 @@ export default function useLessonDetail(lessonId: number) {
         .map((i) => ({ id: i.id, label: i.name })),
       commonValues,
       students,
+      individualItems,
       context: {
         academyName: lesson.academy_name,
         teacherName: '',

--- a/src/lib/exportExcel.ts
+++ b/src/lib/exportExcel.ts
@@ -2,11 +2,17 @@ import * as XLSX from 'xlsx'
 import type { LessonStudent } from '@/types/lessonStudent'
 import { generateStudentMessage } from './generateStudentMessage'
 
+interface CommonItem {
+  id: number
+  label: string
+}
+
 interface LessonExportOptions {
   title: string
-  commonItems: { id: number; label: string }[]
+  commonItems: CommonItem[]
   commonValues: Record<number, string>
   students: LessonStudent[]
+  individualItems: CommonItem[]
   context: {
     academyName: string
     teacherName: string
@@ -20,17 +26,23 @@ export function exportLessonExcel({
   commonItems,
   commonValues,
   students,
+  individualItems,
   context,
 }: LessonExportOptions) {
-  const commonRows = commonItems.map((item) => [item.label, commonValues[item.id] || ''])
-  const studentRows = students.map((s) => [
-    s.name,
-    s.attendance ?? '미입력',
-    s.homework ?? '미입력',
-    s.answerNote ?? '미입력',
-    s.score || '0',
-    s.memo || '',
-  ])
+  const commonRows = commonItems.map((item) => [item.label, commonValues[item.id] ?? ''])
+
+  const individualHeaders = ['이름', '출결', ...individualItems.map((i) => i.label)]
+
+  const studentRows = students.map((s) => {
+    const itemValues = individualItems.map((meta) => {
+      const found = s.items.find((i) => i.template_item_id === meta.id)
+      if (!found) return ''
+      if (found.is_completed === true) return '완료'
+      if (found.is_completed === false) return '미완료'
+      return found.value || ''
+    })
+    return [s.name, s.attendance ?? '미입력', ...itemValues]
+  })
 
   const ws = XLSX.utils.aoa_to_sheet([
     [title],
@@ -39,13 +51,16 @@ export function exportLessonExcel({
     ...commonRows,
     [],
     ['개별 내용'],
-    ['이름', '출결', '숙제', '오답노트', '시험 점수', '메모'],
+    individualHeaders,
     ...studentRows,
   ])
 
   const wsMessages = XLSX.utils.aoa_to_sheet([
     ['이름', '문자 내용'],
-    ...students.map((s) => [s.name, generateStudentMessage(s, commonValues, context)]),
+    ...students.map((s) => [
+      s.name,
+      generateStudentMessage(s, commonItems, commonValues, individualItems, context),
+    ]),
   ])
 
   const wb = XLSX.utils.book_new()

--- a/src/lib/generateStudentMessage.ts
+++ b/src/lib/generateStudentMessage.ts
@@ -7,20 +7,39 @@ export interface MessageContext {
   lessonDate: string
 }
 
+interface ItemMeta {
+  id: number
+  label: string
+}
+
 export function generateStudentMessage(
   student: LessonStudent,
+  commonItems: ItemMeta[],
   commonValues: Record<number, string>,
+  individualItems: ItemMeta[],
   context: MessageContext,
 ): string {
-  return `안녕하세요, ${context.academyName} ${context.teacherName} 강사입니다.
-${context.className} ${context.lessonDate} 수업 결과입니다.
+  const commonLines = commonItems
+    .map((item) => `• ${item.label}: ${commonValues[item.id] || '-'}`)
+    .join('\n')
 
-• 오늘 학습 내용: ${commonValues[1] || '-'}
-• 다음 시간 범위: ${commonValues[2] || '-'}
-• 클리닉 안내: ${commonValues[3] || '-'}
+  const individualLines = individualItems
+    .map((meta) => {
+      const found = student.items.find((i) => i.template_item_id === meta.id)
+      if (!found) return `• ${meta.label}: -`
+      if (found.is_completed === true) return `• ${meta.label}: 완료`
+      if (found.is_completed === false) return `• ${meta.label}: 미완료`
+      return `• ${meta.label}: ${found.value || '-'}`
+    })
+    .join('\n')
 
-• 출결: ${student.attendance || '미입력'}
-• 시험 점수: ${student.score || '0'}점
+  const header = `안녕하세요, ${context.academyName} ${context.teacherName ? context.teacherName + ' 강사' : ''}입니다.\n${context.className} ${context.lessonDate} 수업 결과입니다.`
 
-감사합니다.`
+  const sections = [header]
+  if (commonLines) sections.push(commonLines)
+  if (individualLines) sections.push(`• 출결: ${student.attendance || '미입력'}\n${individualLines}`)
+  else sections.push(`• 출결: ${student.attendance || '미입력'}`)
+  sections.push('감사합니다.')
+
+  return sections.join('\n\n')
 }


### PR DESCRIPTION
## 이슈 넘버

- close #59 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
### 문제
엑셀 다운로드 시 존재하지 않는 필드(s.homework, s.answerNote, s.score, s.memo)를 참조하고, 문자 내용에서 commonValues[1] 등 id를 하드코딩하여 더미 데이터가 출력됨
### 수정
- exportExcel.ts — 하드코딩 컬럼 제거, individualItems 파라미터 추가 후 s.items 기반 동적 렌더링. 완료형 항목은 - - is_completed 값에 따라 완료/미완료/value 표시
- generateStudentMessage.ts — commonItems, individualItems 파라미터 추가, 하드코딩 id 제거 후 동적 생성
- useLessonDetail.ts — handleExcelDownload에서 individualItems 필터링 후 전달