### PR TITLE
fix: 학생 상세 모달 완료 처리 시 완료율 실시간 미반영 수정

### DIFF
--- a/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.tsx
+++ b/src/app/(main)/management/_components/StudentDetailModal/StudentDetailModal.tsx
@@ -70,6 +70,10 @@ export default function StudentDetailModal({
                 ...prev.stats,
                 total_incomplete_items: prev.stats.total_incomplete_items - 1,
                 total_complete_items: prev.stats.total_complete_items + 1,
+
+                completion_rate:
+                  (prev.stats.total_complete_items + 1) /
+                  (prev.stats.total_complete_items + 1 + prev.stats.total_incomplete_items - 1),
               },
             }
           : prev
@@ -154,12 +158,12 @@ export default function StudentDetailModal({
                 <div className={statCardStyle}>
                   <span className={statLabelStyle}>완료율</span>
                   <span className={statValueStyle} style={{ color: '#1DAA7F' }}>
-                    {detail.stats.completion_rate * 100}%
+                    {Math.round(detail.stats.completion_rate * 100)}%
                   </span>
                 </div>
                 <div className={statCardStyle}>
                   <span className={statLabelStyle}>완료</span>
-                  <span className={statValueStyle}>{detail.stats.total_complete_items}회</span>
+                  <span className={statValueStyle}>{detail.stats.total_complete_items}개</span>
                 </div>
                 <div className={statCardStyle}>
                   <span className={statLabelStyle}>미완료</span>
@@ -171,7 +175,8 @@ export default function StudentDetailModal({
             {/* 미완료 항목 */}
             <div className={sectionStyle}>
               <Text variant="headingMd" as="h3" className={sectionTitleStyle}>
-                미완료 항목 <span style={{ color: '#3B51CC' }}>{detail.incomplete_items.length}</span>
+                미완료 항목{' '}
+                <span style={{ color: '#3B51CC' }}>{detail.incomplete_items.length}</span>
               </Text>
               <div className={trackingListStyle}>
                 {detail.incomplete_items.length === 0 ? (


### PR DESCRIPTION
## 이슈 넘버

- close #61 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
### 문제
미완료 항목 완료 처리 시 `total_complete_items`,`total_incomplete_items`는 업데이트되나 `completion_rate`가 재계산되지 않아 완료율이 즉시 반영되지 않음

### 수정
- handleComplete: 완료 처리 후 `completion_rate` 즉시 재계산
- 완료율 표시: `Math.round` 추가로 소수점 방지
### 내용