### PR TITLE
feat: 학생 폼/테이블 UX 개선

### DIFF
--- a/src/app/(main)/management/[id]/_components/AddStudentModal/AddStudentModal.tsx
+++ b/src/app/(main)/management/[id]/_components/AddStudentModal/AddStudentModal.tsx
@@ -38,9 +38,7 @@ export default function AddStudentModal({ isOpen, onClose, onConfirm }: AddStude
     studentService.getStudents().then((res) => setCandidates(res.data))
   }, [isOpen])
 
-  const filtered = candidates.filter(
-    (s) => s.name.includes(search) || s.phone.includes(search)
-  )
+  const filtered = candidates.filter((s) => s.name.includes(search) || s.phone.includes(search))
 
   const handleClose = () => {
     setSearch('')
@@ -85,7 +83,9 @@ export default function AddStudentModal({ isOpen, onClose, onConfirm }: AddStude
         )}
       </div>
       <div className={actionsStyle}>
-        <Button variant="ghost" size="lg" fullWidth onClick={handleClose}>취소</Button>
+        <Button variant="ghost" size="lg" fullWidth onClick={handleClose}>
+          취소
+        </Button>
         <Button
           variant="primary"
           size="lg"

--- a/src/app/(main)/management/[id]/_components/AddStudentModal/AddStudentModal.tsx
+++ b/src/app/(main)/management/[id]/_components/AddStudentModal/AddStudentModal.tsx
@@ -26,9 +26,15 @@ interface AddStudentModalProps {
   isOpen: boolean
   onClose: () => void
   onConfirm: (studentIds: number[]) => void
+  currentStudentIds?: number[]
 }
 
-export default function AddStudentModal({ isOpen, onClose, onConfirm }: AddStudentModalProps) {
+export default function AddStudentModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  currentStudentIds = []
+}: AddStudentModalProps) {
   const [search, setSearch] = useState('')
   const [candidates, setCandidates] = useState<Student[]>([])
   const { items: selectedIds, toggle: toggleSelect, reset: resetIds } = useToggleArray<number>()
@@ -38,7 +44,10 @@ export default function AddStudentModal({ isOpen, onClose, onConfirm }: AddStude
     studentService.getStudents().then((res) => setCandidates(res.data))
   }, [isOpen])
 
-  const filtered = candidates.filter((s) => s.name.includes(search) || s.phone.includes(search))
+  // filtered 수정 — 이미 소속된 학생 제외
+  const filtered = candidates
+    .filter((s) => !currentStudentIds.includes(s.id))
+    .filter((s) => s.name.includes(search) || s.phone.includes(search))
 
   const handleClose = () => {
     setSearch('')

--- a/src/app/(main)/management/[id]/page.tsx
+++ b/src/app/(main)/management/[id]/page.tsx
@@ -102,7 +102,9 @@ export default function ClassDetailPage({ params }: { params: Promise<{ id: stri
         >
           <ArrowLeftIcon width={24} height={24} />
         </button>
-        <Text variant="display" as="h1">{classDetail.name}</Text>
+        <Text variant="display" as="h1">
+          {classDetail.name}
+        </Text>
       </div>
 
       {/* 반 정보 */}
@@ -128,7 +130,7 @@ export default function ClassDetailPage({ params }: { params: Promise<{ id: stri
                   name: data.name,
                   day_of_week: data.dayOfWeek,
                 })
-                setClassDetail((prev) => prev ? { ...prev, ...updated } : prev)
+                setClassDetail((prev) => (prev ? { ...prev, ...updated } : prev))
                 editClass.close()
                 addToast({ variant: 'success', message: '반 정보가 수정됐어요.' })
               } catch {
@@ -153,7 +155,14 @@ export default function ClassDetailPage({ params }: { params: Promise<{ id: stri
 
       {/* 학생 명단 */}
       <section>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: '24px',
+          }}
+        >
           <Text variant="headingMd">학생 명단</Text>
           <Button
             variant="primary"
@@ -182,12 +191,7 @@ export default function ClassDetailPage({ params }: { params: Promise<{ id: stri
         </div>
         <StudentTable
           students={students}
-          middleColumns={[
-            {
-              header: '메모',
-              render: (student) => student.memo ?? '',
-            },
-          ]}
+          middleColumns={[]}
           onDelete={(id) => setDeleteStudentTarget(id)}
           onRowClick={(id) => setSelectedStudentId(id)}
         />

--- a/src/app/(main)/management/[id]/page.tsx
+++ b/src/app/(main)/management/[id]/page.tsx
@@ -166,6 +166,7 @@ export default function ClassDetailPage({ params }: { params: Promise<{ id: stri
           <AddStudentModal
             isOpen={addStudent.isOpen}
             onClose={addStudent.close}
+            currentStudentIds={students.map((s) => s.id)}
             onConfirm={async (ids) => {
               try {
                 await classService.addStudents(classId, ids)

--- a/src/app/(main)/management/_components/AddStudentFormModal/AddStudentFormModal.tsx
+++ b/src/app/(main)/management/_components/AddStudentFormModal/AddStudentFormModal.tsx
@@ -54,7 +54,7 @@ export default function AddStudentFormModal({
   useEffect(() => {
     if (!isOpen) return
     classService
-      .getClasses()
+      .getClasses({ status: 'active' })
       .then((res) => {
         setClasses(res.data)
         // classes 로드 후 defaultValues 적용

--- a/src/app/(main)/management/_components/AddStudentFormModal/AddStudentFormModal.tsx
+++ b/src/app/(main)/management/_components/AddStudentFormModal/AddStudentFormModal.tsx
@@ -90,6 +90,13 @@ export default function AddStudentFormModal({
     handleClose()
   }
 
+  const formatPhone = (value: string) => {
+    const digits = value.replace(/\D/g, '').slice(0, 11)
+    if (digits.length < 4) return digits
+    if (digits.length < 8) return `${digits.slice(0, 3)}-${digits.slice(3)}`
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`
+  }
+
   return (
     <Modal isOpen={isOpen} onClose={handleClose} size="md">
       <div style={{ marginBottom: '24px' }}>
@@ -106,14 +113,20 @@ export default function AddStudentFormModal({
         </div>
         <div className={fieldStyle}>
           <span className={labelStyle}>학생 전화번호</span>
-          <Input variant="gray" value={phone} onChange={(e) => setPhone(e.target.value)} />
+          <Input
+            variant="gray"
+            value={phone}
+            placeholder="숫자만 입력"
+            onChange={(e) => setPhone(formatPhone(e.target.value))}
+          />
         </div>
         <div className={fieldStyle}>
           <span className={labelStyle}>학부모 전화번호</span>
           <Input
             variant="gray"
             value={parentPhone}
-            onChange={(e) => setParentPhone(e.target.value)}
+            placeholder="숫자만 입력"
+            onChange={(e) => setParentPhone(formatPhone(e.target.value))}
           />
         </div>
         <div className={fieldStyle}>

--- a/src/app/(main)/management/_components/StudentTable/StudentTable.tsx
+++ b/src/app/(main)/management/_components/StudentTable/StudentTable.tsx
@@ -38,9 +38,10 @@ function getCellPaddingRight(totalColumns: number): number {
   return 16
 }
 
-function getProgressColor(rate: number): string {
-  if (rate >= 70) return colors.success500
-  if (rate >= 40) return colors.warning500
+function getProgressColor(rate: number, totalIncomplete: number): string {
+  if (rate === 0 && totalIncomplete === 0) return colors.gray500
+  if (rate >= 0.7) return colors.success500
+  if (rate >= 0.4) return colors.warning500
   return colors.error500
 }
 
@@ -84,7 +85,7 @@ export default function StudentTable({
       </thead>
       <tbody>
         {students.map((student) => {
-          const color = getProgressColor(student.completion_rate * 100)
+          const color = getProgressColor(student.completion_rate, student.total_incomplete_items)
           return (
             <tr
               key={student.id}
@@ -111,7 +112,11 @@ export default function StudentTable({
                   </div>
                   <span className={percentTextStyle}>{student.completion_rate * 100}%</span>
                   <span className={remainingTextStyle} style={{ color }}>
-                    {student.total_incomplete_items ?? '-'}개 남음
+                    {student.completion_rate === 1
+                      ? '모두 완료'
+                      : student.completion_rate === 0 && student.total_incomplete_items === 0
+                        ? null
+                        : `${student.total_incomplete_items}개 남음`}
                   </span>
                   <button
                     className={deleteButtonStyle}


### PR DESCRIPTION
## 이슈 넘버

- close #63 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- 전화번호 입력 마스크 — AddStudentFormModal에 formatPhone 유틸 추가
- 학생 등록 시 종료된 반 미노출 — getClasses({ status: 'active' }) 필터 적용
- 소속 학생 미노출 — AddStudentModal에 currentStudentIds prop 추가 후 필터링
- 반 상세 메모 컬럼 제거 — middleColumns={[]} 으로 수정 (school_name은 백엔드 응답 추가 후 자동 반영)
- 완료율 텍스트 케이스 개선: 100% → 모두 완료, 태스크 없음(0%·0개) → 미표시, 나머지 → N개 남음
