### PR TITLE
feat: 템플릿 입력 UX 개선

### DIFF
--- a/src/app/(main)/lesson/[id]/lessonDetail.css.ts
+++ b/src/app/(main)/lesson/[id]/lessonDetail.css.ts
@@ -23,6 +23,11 @@ export const backButtonStyle = style({
   color: colors.gray500,
   display: 'flex',
   alignItems: 'center',
+  selectors: {
+    '&:hover': {
+      color: colors.gray700,
+    },
+  },
 })
 
 export const headerLeftStyle = style({

--- a/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.tsx
+++ b/src/app/(main)/lesson/_components/TemplateSelectModal/TemplateSelectModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Modal from '@/components/common/Modal'
 import Text from '@/components/common/Text'
 import Button from '@/components/common/Button'
@@ -37,6 +38,7 @@ export default function TemplateSelectModal({
   title = '템플릿 선택',
   confirmLabel = '확인',
 }: TemplateSelectModalProps) {
+  const router = useRouter()
   const [templates, setTemplates] = useState<Template[]>([])
   const [selectedId, setSelectedId] = useState<number | null>(null)
   const [currentDetail, setCurrentDetail] = useState<TemplateDetail | null>(null)
@@ -106,9 +108,7 @@ export default function TemplateSelectModal({
                   </div>
                 </>
               ) : (
-                <Text variant="bodyMd" color="gray500">
-                  -
-                </Text>
+                <Text variant="bodyMd" color="gray500">-</Text>
               )}
             </div>
 
@@ -146,17 +146,24 @@ export default function TemplateSelectModal({
         ) : (
           // 최초 선택 모드 - 칩 목록
           <>
-            <div className={chipGroupStyle}>
-              {templates.map((t) => (
-                <button
-                  key={t.id}
-                  className={chipButtonRecipe({ selected: selectedId === t.id })}
-                  onClick={() => handleSelect(String(t.id))}
-                >
-                  {t.name}
-                </button>
-              ))}
-            </div>
+            {templates.length === 0 ? (
+              <div style={{ padding: '24px 0', textAlign: 'center', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                <Text variant="bodyMd" color="gray500">등록된 템플릿이 없어요.</Text>
+                <Text variant="bodyMd" color="gray500">템플릿을 먼저 만들어주세요.</Text>
+              </div>
+            ) : (
+              <div className={chipGroupStyle}>
+                {templates.map((t) => (
+                  <button
+                    key={t.id}
+                    className={chipButtonRecipe({ selected: selectedId === t.id })}
+                    onClick={() => handleSelect(String(t.id))}
+                  >
+                    {t.name}
+                  </button>
+                ))}
+              </div>
+            )}
             {selectedDetail && (
               <div className={itemChipGroupStyle}>
                 {selectedDetail.items.map((item) => (
@@ -172,18 +179,26 @@ export default function TemplateSelectModal({
         )}
 
         <div className={actionsStyle}>
-          <Button variant="ghost" size="md" fullWidth onClick={handleClose}>
-            취소
-          </Button>
-          <Button
-            variant="primary"
-            size="md"
-            fullWidth
-            onClick={handleConfirm}
-            disabled={!selectedId || isLoading}
-          >
-            {confirmLabel}
-          </Button>
+          {templates.length === 0 && !currentTemplateId ? (
+            <Button variant="primary" size="md" fullWidth onClick={() => router.push('/template/new')}>
+              템플릿 만들러 가기
+            </Button>
+          ) : (
+            <>
+              <Button variant="ghost" size="md" fullWidth onClick={handleClose}>
+                취소
+              </Button>
+              <Button
+                variant="primary"
+                size="md"
+                fullWidth
+                onClick={handleConfirm}
+                disabled={!selectedId || isLoading}
+              >
+                {confirmLabel}
+              </Button>
+            </>
+          )}
         </div>
       </div>
     </Modal>

--- a/src/app/(main)/management/[id]/page.tsx
+++ b/src/app/(main)/management/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { colors } from '@/styles/tokens/colors'
+
 import useDisclosure from '@/hooks/useDisclosure'
 import Text from '@/components/common/Text'
 import Button from '@/components/common/Button'
@@ -20,6 +20,7 @@ import StudentDetailModal from '../_components/StudentDetailModal/StudentDetailM
 import { classService, type ClassDetail } from '@/services/class'
 import { useToastStore } from '@/stores/toastStore'
 import type { Student } from '@/types/student'
+import { backButtonStyle } from '../management.css'
 
 const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토']
 const formatSchedule = (schedules: { day_of_week: number }[]) =>
@@ -96,10 +97,7 @@ export default function ClassDetailPage({ params }: { params: Promise<{ id: stri
     <div style={{ display: 'flex', flexDirection: 'column', gap: '60px' }}>
       {/* 헤더 */}
       <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-        <button
-          onClick={() => router.back()}
-          style={{ background: 'none', border: 'none', cursor: 'pointer', color: colors.gray500 }}
-        >
+        <button onClick={() => router.back()} className={backButtonStyle}>
           <ArrowLeftIcon width={24} height={24} />
         </button>
         <Text variant="display" as="h1">

--- a/src/app/(main)/management/management.css.ts
+++ b/src/app/(main)/management/management.css.ts
@@ -40,3 +40,17 @@ export const gridStyle = style({
   ...cardGridResponsive,
   gridAutoRows: 'minmax(190px, auto)',
 })
+
+export const backButtonStyle = style({
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: colors.gray500,
+  display: 'flex',
+  alignItems: 'center',
+  selectors: {
+    '&:hover': {
+      color: colors.gray700,
+    },
+  },
+})

--- a/src/app/(main)/template/_components/TemplateName/TemplateName.tsx
+++ b/src/app/(main)/template/_components/TemplateName/TemplateName.tsx
@@ -5,16 +5,20 @@ import { sectionStyle } from './TemplateName.css'
 interface TemplateNameProps {
   value: string
   onChange: (value: string) => void
+  hasError?: boolean
 }
 
-export default function TemplateNameSection({ value, onChange }: TemplateNameProps) {
+export default function TemplateNameSection({ value, onChange, hasError }: TemplateNameProps) {
   return (
     <div className={sectionStyle}>
-      <Text variant="headingMd" as="h2">템플릿 이름</Text>
+      <Text variant="headingMd" as="h2">
+        템플릿 이름 <span style={{ color: '#EF4453' }}>*</span>
+      </Text>
       <Input
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder="예) 정규 수업 템플릿"
+        hasError={hasError}
       />
     </div>
   )

--- a/src/app/(main)/template/new/page.tsx
+++ b/src/app/(main)/template/new/page.tsx
@@ -1,7 +1,10 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import Text from '@/components/common/Text'
 import Button from '@/components/common/Button'
+import ArrowLeftIcon from '@/assets/icons/icon-arrow-left.svg'
+import SaveIcon from '@/assets/icons/icon-save.svg'
 import TemplateName from '../_components/TemplateName/TemplateName'
 import ContentSection from '../_components/ContentSection/ContentSection'
 import MessageSettings from '../_components/MessageSettings/MessageSettings'
@@ -11,8 +14,10 @@ import {
   leftSectionStyle,
   rightSectionStyle,
   sectionBoxStyle,
+  formHeaderStyle,
+  formHeaderLeftStyle,
+  formBackButtonStyle,
 } from '../template-form.css'
-import SaveIcon from '@/assets/icons/icon-save.svg'
 import useTemplateEditor from '@/hooks/useTemplateEditor'
 import type { TemplateItem } from '../_types/template'
 
@@ -27,21 +32,20 @@ const ATTENDANCE_DISPLAY: TemplateItem = {
 }
 
 export default function TemplateNewPage() {
+  const router = useRouter()
   const editor = useTemplateEditor()
 
   return (
     <>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginBottom: '32px',
-        }}
-      >
-        <Text variant="display" as="h1">
-          수업 템플릿 생성
-        </Text>
+      <div className={formHeaderStyle}>
+        <div className={formHeaderLeftStyle}>
+          <button className={formBackButtonStyle} onClick={() => router.push('/template')}>
+            <ArrowLeftIcon width={24} height={24} />
+          </button>
+          <Text variant="display" as="h1">
+            수업 템플릿 생성
+          </Text>
+        </div>
         <Button
           variant="primary"
           size="sm"

--- a/src/app/(main)/template/template-form.css.ts
+++ b/src/app/(main)/template/template-form.css.ts
@@ -46,4 +46,9 @@ export const formBackButtonStyle = style({
   color: colors.gray500,
   display: 'flex',
   alignItems: 'center',
+  selectors: {
+    '&:hover': {
+      color: colors.gray700,
+    },
+  },
 })

--- a/src/components/common/Input/Input.css.ts
+++ b/src/components/common/Input/Input.css.ts
@@ -38,6 +38,16 @@ export const inputRecipe = recipe({
         border: `1px solid ${colors.gray50}`,
       },
     },
+    hasError: {
+      true: {
+        borderColor: colors.error500,
+        selectors: {
+          '&:focus': {
+            borderColor: colors.error500,
+          },
+        },
+      },
+    },
     shape: {
       square: {
         height: '48px',

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -4,11 +4,12 @@ import { inputRecipe } from './Input.css'
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   variant?: 'default' | 'gray'
   shape?: 'square' | 'capsule'
+  hasError?: boolean
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ variant = 'default', shape = 'square', ...props }, ref) => {
-    return <input ref={ref} className={inputRecipe({ variant, shape })} {...props} />
+  ({ variant = 'default', shape = 'square', hasError = false, ...props }, ref) => {
+    return <input ref={ref} className={inputRecipe({ variant, shape, hasError })} {...props} />
   }
 )
 

--- a/src/hooks/useTemplateEditor.ts
+++ b/src/hooks/useTemplateEditor.ts
@@ -16,6 +16,7 @@ export default function useTemplateEditor(initial: InitialData = {}) {
   const router = useRouter()
   const addToast = useToastStore((s) => s.addToast)
   const [isSaving, setIsSaving] = useState(false)
+  const [hasNameError, setHasNameError] = useState(false)
 
   const initCommon = initial.commonItems ?? INITIAL_COMMON_ITEMS
   const initIndividual = initial.individualItems ?? INITIAL_INDIVIDUAL_ITEMS
@@ -31,7 +32,7 @@ export default function useTemplateEditor(initial: InitialData = {}) {
   const [originalItemIds] = useState<number[]>(() => {
     const itemIds = [...(initial.commonItems ?? []), ...(initial.individualItems ?? [])]
       .map((item) => Number(item.id))
-      .filter((id) => !isNaN(id) && id > 0) // 새로 추가한 'c-xxx', 'i-xxx' 제외
+      .filter((id) => !isNaN(id) && id > 0)
     return [...itemIds, ...(initial.attendanceItemIds ?? [])]
   })
 
@@ -72,11 +73,18 @@ export default function useTemplateEditor(initial: InitialData = {}) {
         options: item.choices ?? [],
       }))
 
+  const handleTemplateNameChange = (value: string) => {
+    setTemplateName(value)
+    if (hasNameError && value.trim()) setHasNameError(false)
+  }
+
   const handleSave = async () => {
     if (!templateName.trim()) {
       addToast({ variant: 'warning', message: '템플릿 이름을 입력해주세요.' })
+      setHasNameError(true)
       return
     }
+    setHasNameError(false)
     setIsSaving(true)
     try {
       await templateService.createTemplate({
@@ -97,14 +105,16 @@ export default function useTemplateEditor(initial: InitialData = {}) {
   const handleUpdate = async (templateId: number) => {
     if (!templateName.trim()) {
       addToast({ variant: 'warning', message: '템플릿 이름을 입력해주세요.' })
+      setHasNameError(true)
       return
     }
+    setHasNameError(false)
     setIsSaving(true)
     try {
       await templateService.updateTemplate(templateId, {
         name: templateName,
         items: [ATTENDANCE_ITEM, ...buildItems([...commonItems, ...individualItems])],
-        deleted_item_ids: originalItemIds, // 기존 아이템 전부 삭제 후 새로 삽입
+        deleted_item_ids: originalItemIds,
       })
       addToast({ variant: 'success', message: '템플릿이 수정됐어요.' })
       router.push('/template')
@@ -188,6 +198,8 @@ export default function useTemplateEditor(initial: InitialData = {}) {
   return {
     templateName,
     setTemplateName,
+    hasNameError,
+    handleTemplateNameChange,
     commonItems,
     individualItems,
     messageOrder,


### PR DESCRIPTION
## 이슈 넘버

- close #65 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- [ ] 템플릿 이름 레이블에 필수 * 표시 추가
- [ ] 저장 시 템플릿 이름 미입력이면 토스트 + Input 테두리 error500 하이라이트, 입력 시 에러 해제
- [ ] 템플릿 목록이 비어있을 때 안내 메시지 표시 및 "템플릿 만들러 가기" 버튼으로 /template/new 이동
