### PR TITLE
fix: 템플릿 수정 재진입 시 문자 순서 미반영 버그 수정

### DIFF
--- a/src/hooks/useTemplateEditor.ts
+++ b/src/hooks/useTemplateEditor.ts
@@ -10,6 +10,7 @@ interface InitialData {
   commonItems?: TemplateItem[]
   individualItems?: TemplateItem[]
   attendanceItemIds?: number[]
+  messageOrder?: string[]
 }
 
 export default function useTemplateEditor(initial: InitialData = {}) {
@@ -25,15 +26,16 @@ export default function useTemplateEditor(initial: InitialData = {}) {
   const [commonItems, setCommonItems] = useState<TemplateItem[]>(initCommon)
   const [individualItems, setIndividualItems] = useState<TemplateItem[]>(initIndividual)
   const [deletedItemIds, setDeletedItemIds] = useState<number[]>([])
-  const [messageOrder, setMessageOrder] = useState<string[]>([
-    ...initCommon.map((i) => i.id),
-    '__attendance__',
-    ...initIndividual.map((i) => i.id),
-  ])
+  const [messageOrder, setMessageOrder] = useState<string[]>(
+    initial.messageOrder ?? [
+      ...initCommon.map((i) => i.id),
+      '__attendance__',
+      ...initIndividual.map((i) => i.id),
+    ]
+  )
 
   const allItemsMap = useMemo(() => {
     const map = new Map<string, TemplateItem>()
-    // 출결 고정 항목 추가
     map.set('__attendance__', {
       id: '__attendance__',
       label: '출결',
@@ -57,27 +59,19 @@ export default function useTemplateEditor(initial: InitialData = {}) {
     attendance: 'ATTENDANCE',
   }
 
-  const ATTENDANCE_ITEM: CreateTemplateItemDto = {
-    name: '출결',
-    item_type: 'ATTENDANCE',
-    is_common: false,
-    include_in_message: true,
-    sort_order: 0,
-    options: [],
-  }
-
   const buildItems = (items: TemplateItem[]): CreateTemplateItemDto[] =>
     items
       .filter((item) => item.label.trim() !== '' && item.itemType !== 'attendance')
-      .map((item, index) => {
+      .map((item) => {
         const numericId = Number(item.id)
+        const sortOrder = messageOrder.indexOf(item.id)
         return {
           ...(numericId > 0 ? { id: numericId } : {}),
           name: item.label,
           item_type: ITEM_TYPE_MAP[item.itemType],
           is_common: item.category === 'common',
           include_in_message: item.isInMessage,
-          sort_order: index + 1,
+          sort_order: sortOrder >= 0 ? sortOrder : 999,
           options: item.choices ?? [],
         }
       })
@@ -95,6 +89,15 @@ export default function useTemplateEditor(initial: InitialData = {}) {
     }
     setHasNameError(false)
     setIsSaving(true)
+    const attendanceSortOrder = messageOrder.indexOf('__attendance__')
+    const ATTENDANCE_ITEM: CreateTemplateItemDto = {
+      name: '출결',
+      item_type: 'ATTENDANCE',
+      is_common: false,
+      include_in_message: true,
+      sort_order: attendanceSortOrder >= 0 ? attendanceSortOrder : 0,
+      options: [],
+    }
     try {
       await templateService.createTemplate({
         name: templateName,
@@ -119,6 +122,15 @@ export default function useTemplateEditor(initial: InitialData = {}) {
     }
     setHasNameError(false)
     setIsSaving(true)
+    const attendanceSortOrder = messageOrder.indexOf('__attendance__')
+    const ATTENDANCE_ITEM: CreateTemplateItemDto = {
+      name: '출결',
+      item_type: 'ATTENDANCE',
+      is_common: false,
+      include_in_message: true,
+      sort_order: attendanceSortOrder >= 0 ? attendanceSortOrder : 0,
+      options: [],
+    }
     try {
       await templateService.updateTemplate(templateId, {
         name: templateName,

--- a/src/services/template.ts
+++ b/src/services/template.ts
@@ -88,21 +88,17 @@ export const toEditorItems = (detail: TemplateDetail) => {
     choices: item.options?.map((o: any) => (typeof o === 'string' ? o : o.label)) ?? [],
   })
 
-  // 출결 아이템을 EditorItem으로 변환 (attendance 타입)
-  const attendanceEditorItems: EditorItem[] = attendanceItems.map((item) => ({
-    id: String(item.id),
-    label: item.name,
-    isActive: true,
-    isInMessage: item.include_in_message,
-    category: 'individual' as const,
-    itemType: 'attendance' as const,
-  }))
+  // sort_order 기준으로 messageOrder 복원 (출결은 __attendance__로 치환)
+  const messageOrder = sorted
+    .map((i) => (i.item_type === 'ATTENDANCE' ? '__attendance__' : String(i.id)))
+    .filter((id, index, self) => self.indexOf(id) === index) // 중복 제거
 
   return {
     name: detail.name,
     commonItems: nonAttendance.filter((i) => i.is_common).map(toItem),
     individualItems: nonAttendance.filter((i) => !i.is_common).map(toItem),
     attendanceItemIds,
+    messageOrder,
   }
 }
 


### PR DESCRIPTION
## 이슈 넘버

- close #83 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항

<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] buildItems에서 messageOrder 기준으로 sort_order 설정
- [x] ATTENDANCE_ITEM sort_order 동적으로 설정
- [x] toEditorItems에서 sort_order 기준으로 messageOrder 복원
- [x] useTemplateEditor InitialData에 messageOrder 추가